### PR TITLE
1.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  env: {
+    browser: true,
+    es6: true
+  },
+  extends: 'eslint:recommended',
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  },
+  globals: Object.assign({
+    console: true,
+    server: true
+  }),
+  rules: {
+    'no-console': 0
+  }
+};

--- a/README.md
+++ b/README.md
@@ -1,26 +1,109 @@
-# Ember-cli-mirage-nested
+# ember-cli-mirage-nested
 
-Define your Mirage scenario with nested syntax such as:
+This addon does two different things at the moment and will be soon split into **ember-cli-mirage-scenario-chaining** and **ember-cli-mirage-gui**
 
-`````
-server.create('parent').hasOne('child').hasOne('grandChild');
-`````
-
-# Usage
-
-Extend your Mirage models from the bg-model in this addon, for example:
-
-`````
-import Model from 'ember-cli-mirage-nested/mirage/bg-model';
-
-export default Model.extend({
-  childrenAssociations: ['children'],
-  allowChangeNbAssociations: ['children'],
-  children: hasMany('grand-child', {inverse: 'parent'}),
-  parent: belongsTo('parent')
-});
-`````
 
 # Demo
 
 https://britishgas-engineering.github.io/ember-cli-mirage-nested
+
+# 1) ember-cli-mirage-scenario-chaining
+
+Define your Mirage scenario with nested syntax such as:
+
+```javascript
+server.create('parent').hasOne('child').hasOne('grandChild');
+```
+
+### Features
+
+We created a few very useful methods to be used on Mirage models (once they are extended using our mixin), allowing to easily create scenarii:
+
+* `hasOne` : the parent model instance has one and only one child model instance (given a relationship parent to child has been set).
+example:
+```javascript
+//mirage/scenarios/default.js
+const parent = server.create('parent');
+const child = parent.hasOne('child', {propertyOfTheChild: value})
+parent.child === child //true
+```
+
+* `hasMulti` : the parent model instance has multiple child model instance (given a `hasMany` relationship parent to child has been set).
+example:
+```javascript
+//mirage/scenarios/default.js
+const parent = server.create('parent');
+const children = parent.hasMulti('children', 3, {propertyThatAllTheChildrenWillHave: value})
+parent.children.models === children //true
+```
+
+* `hasNo` : the parent model instance has no child model instance (given a relationship parent to child has been set).
+example:
+```javascript
+//mirage/scenarios/default.js
+const parent = server.create('parent');
+parent.hasNo('child');
+parent.child === null //true
+```
+
+* In addition we added a `default` method available for each Mirage model, which will be run whenever a new model instance is created - similar to an `init` method, this allows to create default children relationships on model creation
+
+### Usage
+
+Extend your Mirage models from the bg-model-mixin in this addon, for example:
+
+```javascript
+//mirage/models/bg-model.js
+import { Model } from 'ember-cli-mirage';
+import EmberCliMirageNestedMixin from  'ember-cli-mirage-nested/mirage/bg-model-mixin';
+
+export default Model.extend(EmberCliMirageNestedMixin);
+```
+
+```javascript
+//mirage/models/parent.js
+import BgModel from './bg-model';
+import { hasMany, belongsTo } from 'ember-cli-mirage';
+
+export default BgModel.extend({
+  childrenAssociations: ['children'],//will be destroyed when this model instance is destroyed
+  children: hasMany('child', {inverse: 'parent'})
+  default() {//will be run every time a new "parent" model instance is created
+    const children = this.hasMulti('children', 3);
+  }
+});
+```
+
+# 2) ember-cli-mirage-gui
+
+This addon adds some methods in Mirage models allowing to create a Graphical User Interface in your app to easily create Mirage scenario, like the one in [our demo](https://britishgas-engineering.github.io/ember-cli-mirage-nested).
+
+Only alpha version for now (components for the GUI are in the dummy app of this addon), documentation / wiki is in progress.
+
+Set all the options for this functionality in a `forGUI` object in your model
+
+```javascript
+//mirage/models/parent.js
+import BgModel from './bg-model';
+import { hasMany, belongsTo } from 'ember-cli-mirage';
+
+export default BgModel.extend({
+  childrenAssociations: ['children'],  
+  children: hasMany('child', {inverse: 'parent'}),
+  forGUI: {
+    allowChangeNbAssociations: ['children'],//allows changing the associations in the GUI
+    flags: [{
+      name: 'title',//allow to change the "title" attribute of this model in the GUI
+      displayName: 'titleGui',// (optional) allows to show a different name for the attribute in the GUI
+      options: [//set the options for the title
+        'The title attribute of this model is set on init in the "default" hook of the model.',
+        'Also, this model has two children by default.'
+      ],
+      method: 'updateTitle'//(optional) if set, then you will call this method in the model when changing the GUI instead of changing the attribute
+    }]
+  },
+  default() {//will be run every time a new "parent" model instance is created
+    const children = this.hasMulti('children', 3);
+  }
+});
+```

--- a/app/mirage/bg-model.js
+++ b/app/mirage/bg-model.js
@@ -1,3 +1,0 @@
-import Model from 'ember-cli-mirage-nested/mirage/bg-model';
-
-export default Model;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,33 +4,270 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+      "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.44"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.2.0",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+      "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "lodash": "^4.2.0"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/generator": "7.0.0-beta.44",
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.2.0"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.2.0",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
+    "acorn": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
     "align-text": {
       "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amd-name-resolver": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
-      "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+      "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+      "dev": true,
       "requires": {
-        "ensure-posix-path": "1.0.2"
+        "ensure-posix-path": "^1.0.1"
       }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "ansicolors": {
       "version": "0.3.2",
@@ -44,10 +281,66 @@
       "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
       "dev": true
     },
+    "aot-test-generators": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/aot-test-generators/-/aot-test-generators-0.1.0.tgz",
+      "integrity": "sha1-Q/D2Ffl8spjXkZwbC05rcxCwPNA=",
+      "dev": true,
+      "requires": {
+        "jsesc": "^2.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        }
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
+      }
+    },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
     },
     "asap": {
       "version": "2.0.6",
@@ -59,21 +352,23 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.14.0"
       }
     },
     "async-disk-cache": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.2.tgz",
       "integrity": "sha1-rFPWFShD3yAslAbijXdDYmCNdN0=",
+      "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "heimdalljs": "0.2.5",
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
         "istextorbinary": "2.1.0",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "rsvp": "3.6.2",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.5.3",
+        "rsvp": "^3.0.18",
         "username-sync": "1.0.1"
       }
     },
@@ -81,9 +376,10 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
       "integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==",
+      "dev": true,
       "requires": {
-        "async": "2.5.0",
-        "debug": "2.6.8"
+        "async": "^2.4.1",
+        "debug": "^2.6.8"
       }
     },
     "async-some": {
@@ -92,64 +388,113 @@
       "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
       "dev": true,
       "requires": {
-        "dezalgo": "1.0.3"
+        "dezalgo": "^1.0.2"
       }
     },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
-        "slash": "1.0.0",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-eslint": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
+      "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        }
       }
     },
     "babel-generator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
@@ -157,548 +502,603 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-debug-macros": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz",
-      "integrity": "sha512-hZw5qNNGAR02Y+yBUrtsnJHh8OXavkayPRqKGAXnIm4t5rWVpj3ArwsC7TWdpZsBguQvHAeyTxZ7s23yY60HHg==",
+      "version": "0.2.0-beta.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0-beta.6.tgz",
+      "integrity": "sha1-7N9uQI1chjqyF0DXrX9D8CfS+RI=",
+      "dev": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "^5.3.0"
       }
     },
     "babel-plugin-ember-modules-api-polyfill": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.0.1.tgz",
-      "integrity": "sha1-uq8m3Ovi7R3hIAIbxCvin1IEl7M=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.2.tgz",
+      "integrity": "sha512-mi9gaYasj2Bd6FYD1XCvuU1RL3n4DPn+VdOORyC2nqrvK50cLHkPaq/NdsqfxtZ0WNCIigrwnTHXU3XZI80tPg==",
+      "dev": true,
       "requires": {
-        "ember-rfc176-data": "0.2.7"
+        "ember-rfc176-data": "^0.3.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
         }
       }
     },
     "babel-preset-env": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
-      "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.4.0",
-        "invariant": "2.2.2",
-        "semver": "5.4.1"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-register": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.8",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -706,18 +1106,20 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+        "tweetnacl": "^0.14.3"
       }
     },
     "binaryextensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.0.0.tgz",
-      "integrity": "sha1-5ZfRp6ajVYotHHJBoWyZll5qpA8="
+      "integrity": "sha1-5ZfRp6ajVYotHHJBoWyZll5qpA8=",
+      "dev": true
     },
     "blank-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
-      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk="
+      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk=",
+      "dev": true
     },
     "block-stream": {
       "version": "0.0.9",
@@ -725,15 +1127,16 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+        "inherits": "~2.0.0"
       }
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -743,11 +1146,11 @@
       "integrity": "sha1-9fZurJYr+fCGKGkh8Orqq20A2Bk=",
       "dev": true,
       "requires": {
-        "broccoli-asset-rewrite": "1.1.0",
-        "broccoli-filter": "1.2.4",
-        "json-stable-stringify": "1.0.1",
-        "matcher-collection": "1.0.4",
-        "rsvp": "3.3.3"
+        "broccoli-asset-rewrite": "^1.1.0",
+        "broccoli-filter": "^1.2.2",
+        "json-stable-stringify": "^1.0.0",
+        "matcher-collection": "^1.0.1",
+        "rsvp": "^3.0.6"
       },
       "dependencies": {
         "broccoli-asset-rewrite": {
@@ -756,7 +1159,7 @@
           "integrity": "sha1-d6XaVhV6oxjFkRMkXouvtGF/iDA=",
           "dev": true,
           "requires": {
-            "broccoli-filter": "1.2.4"
+            "broccoli-filter": "^1.2.3"
           }
         },
         "broccoli-filter": {
@@ -765,15 +1168,15 @@
           "integrity": "sha1-QJr7lLmjptqfrIE06R4gX0DMczA=",
           "dev": true,
           "requires": {
-            "broccoli-kitchen-sink-helpers": "0.3.1",
-            "broccoli-plugin": "1.3.0",
-            "copy-dereference": "1.0.0",
-            "debug": "2.3.3",
-            "mkdirp": "0.5.1",
-            "promise-map-series": "0.2.3",
-            "rsvp": "3.3.3",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.1"
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "broccoli-plugin": "^1.0.0",
+            "copy-dereference": "^1.0.0",
+            "debug": "^2.2.0",
+            "mkdirp": "^0.5.1",
+            "promise-map-series": "^0.2.1",
+            "rsvp": "^3.0.18",
+            "symlink-or-copy": "^1.0.1",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "broccoli-kitchen-sink-helpers": {
@@ -782,8 +1185,8 @@
               "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
               "dev": true,
               "requires": {
-                "glob": "5.0.15",
-                "mkdirp": "0.5.1"
+                "glob": "^5.0.10",
+                "mkdirp": "^0.5.1"
               },
               "dependencies": {
                 "glob": {
@@ -792,11 +1195,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -805,8 +1208,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -829,7 +1232,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -838,7 +1241,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -864,7 +1267,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -891,10 +1294,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "quick-temp": {
@@ -903,9 +1306,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -934,7 +1337,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -943,12 +1346,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -963,8 +1366,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -987,7 +1390,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -996,7 +1399,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -1022,7 +1425,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -1091,7 +1494,7 @@
               "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
               "dev": true,
               "requires": {
-                "rsvp": "3.3.3"
+                "rsvp": "^3.0.14"
               }
             },
             "symlink-or-copy": {
@@ -1106,8 +1509,8 @@
               "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
               "dev": true,
               "requires": {
-                "ensure-posix-path": "1.0.2",
-                "matcher-collection": "1.0.4"
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
               },
               "dependencies": {
                 "ensure-posix-path": {
@@ -1126,7 +1529,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           },
           "dependencies": {
             "jsonify": {
@@ -1143,7 +1546,7 @@
           "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
           "dev": true,
           "requires": {
-            "minimatch": "3.0.3"
+            "minimatch": "^3.0.2"
           },
           "dependencies": {
             "minimatch": {
@@ -1152,7 +1555,7 @@
               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -1161,7 +1564,7 @@
                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.4.2",
+                    "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -1192,102 +1595,180 @@
       }
     },
     "broccoli-babel-transpiler": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-      "integrity": "sha512-o1OUe5RZ5EP5+QICEmRNvWlhMvIciMisVACHu6qUPt6dE0Q0UnI5lUpWTmuXg/X+QuznqD/s1PApIpahv/QMZw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.0.tgz",
+      "integrity": "sha512-c5OLGY40Sdmv6rP230Jt8yoK49BHfOw1LXiDMu9EC9k2U6sqlpNRK78SzvByQ8IzKtBYUfeWCxeZHcvW+gH7VQ==",
+      "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-persistent-filter": "1.4.3",
-        "clone": "2.1.1",
-        "hash-for-dep": "1.2.0",
-        "heimdalljs-logger": "0.1.9",
-        "json-stable-stringify": "1.0.1",
-        "rsvp": "3.6.2",
-        "workerpool": "2.2.4"
+        "babel-core": "^6.26.0",
+        "broccoli-funnel": "^2.0.1",
+        "broccoli-merge-trees": "^2.0.0",
+        "broccoli-persistent-filter": "^1.4.3",
+        "clone": "^2.0.0",
+        "hash-for-dep": "^1.2.3",
+        "heimdalljs-logger": "^0.1.7",
+        "json-stable-stringify": "^1.0.0",
+        "rsvp": "^4.8.2",
+        "workerpool": "^2.3.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
+          }
+        },
+        "hash-for-dep": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
+          "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
+          "dev": true,
+          "requires": {
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "heimdalljs": "^0.2.3",
+            "heimdalljs-logger": "^0.1.7",
+            "resolve": "^1.4.0"
+          }
+        },
+        "rsvp": {
+          "version": "4.8.3",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.3.tgz",
+          "integrity": "sha512-/OlbK31XtkPnLD2ktmZXj4g/v6q1boTDr6/3lFuDTgxVsrA3h7PH5eYyAxIvDMjRHr/DoOlzNicqDwBEo9xU7g==",
+          "dev": true
+        }
+      }
+    },
+    "broccoli-concat": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-3.6.0.tgz",
+      "integrity": "sha512-F6hDYiFfiO1zEXEfHbbMujkfsGqvobm/0+TReZYCFXP3UZTc6+UkpWL/89xwJ9FB96Td0zGaCi2eizMUCyXv5g==",
+      "dev": true,
+      "requires": {
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "broccoli-plugin": "^1.3.0",
+        "broccoli-stew": "^1.5.0",
+        "ensure-posix-path": "^1.0.2",
+        "fast-sourcemap-concat": "^1.4.0",
+        "find-index": "^1.1.0",
+        "fs-extra": "^4.0.3",
+        "fs-tree-diff": "^0.5.7",
+        "lodash.merge": "^4.3.1",
+        "lodash.omit": "^4.1.0",
+        "lodash.uniq": "^4.2.0",
+        "walk-sync": "^0.3.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+          "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+          "dev": true,
+          "requires": {
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
       }
     },
     "broccoli-debug": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.3.tgz",
       "integrity": "sha512-YqpMH2QPHNtGoauVOj715dqDfurJa9O2and1UuxfzzGpM3A9mBrXeeLdWpTt8hj/Y8u8WaG/L1UBZYffPvTHVw==",
+      "dev": true,
       "requires": {
-        "broccoli-plugin": "1.3.0",
-        "fs-tree-diff": "0.5.6",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "minimatch": "3.0.4",
-        "symlink-or-copy": "1.1.8",
-        "tree-sync": "1.2.2"
+        "broccoli-plugin": "^1.2.1",
+        "fs-tree-diff": "^0.5.2",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "minimatch": "^3.0.3",
+        "symlink-or-copy": "^1.1.8",
+        "tree-sync": "^1.2.2"
       }
     },
     "broccoli-file-creator": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.1.1.tgz",
-      "integrity": "sha1-GzW2fSFavfrdjUnutpSTw55sNFA=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz",
+      "integrity": "sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==",
+      "dev": true,
       "requires": {
-        "broccoli-kitchen-sink-helpers": "0.2.9",
-        "broccoli-plugin": "1.3.0",
-        "broccoli-writer": "0.1.1",
-        "mkdirp": "0.5.1",
-        "rsvp": "3.0.21",
-        "symlink-or-copy": "1.1.8"
-      },
-      "dependencies": {
-        "broccoli-kitchen-sink-helpers": {
-          "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
-          "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-          "requires": {
-            "glob": "5.0.15",
-            "mkdirp": "0.5.1"
-          }
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "rsvp": {
-          "version": "3.0.21",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.21.tgz",
-          "integrity": "sha1-ScWI/hjvKTvNCrn05nVuasQzNZ8="
-        }
+        "broccoli-plugin": "^1.1.0",
+        "mkdirp": "^0.5.1"
       }
     },
     "broccoli-funnel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
       "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+      "dev": true,
       "requires": {
-        "array-equal": "1.0.0",
-        "blank-object": "1.0.2",
-        "broccoli-plugin": "1.3.0",
-        "debug": "2.6.8",
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
         "exists-sync": "0.0.4",
-        "fast-ordered-set": "1.0.3",
-        "fs-tree-diff": "0.5.6",
-        "heimdalljs": "0.2.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "path-posix": "1.0.0",
-        "rimraf": "2.6.2",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
       },
       "dependencies": {
         "exists-sync": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
-          "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk="
+          "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
+          "dev": true
         }
       }
     },
@@ -1295,131 +1776,153 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
       "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
+      "dev": true,
       "requires": {
-        "glob": "5.0.15",
-        "mkdirp": "0.5.1"
+        "glob": "^5.0.10",
+        "mkdirp": "^0.5.1"
       },
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
+      }
+    },
+    "broccoli-lint-eslint": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/broccoli-lint-eslint/-/broccoli-lint-eslint-4.2.1.tgz",
+      "integrity": "sha512-Jvm06UvuMPa5gEH+9/Sb+QpoIodDAYzbyIUEqxniPCdA6JJooa91hQDCTJc32RUV46JNMcLhb3Dl55BdA8v5mw==",
+      "dev": true,
+      "requires": {
+        "aot-test-generators": "^0.1.0",
+        "broccoli-concat": "^3.2.2",
+        "broccoli-persistent-filter": "^1.4.3",
+        "eslint": "^4.0.0",
+        "json-stable-stringify": "^1.0.1",
+        "lodash.defaultsdeep": "^4.6.0",
+        "md5-hex": "^2.0.0"
       }
     },
     "broccoli-merge-trees": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
       "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
+      "dev": true,
       "requires": {
-        "broccoli-plugin": "1.3.0",
-        "can-symlink": "1.0.0",
-        "fast-ordered-set": "1.0.3",
-        "fs-tree-diff": "0.5.6",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "rimraf": "2.6.2",
-        "symlink-or-copy": "1.1.8"
+        "broccoli-plugin": "^1.3.0",
+        "can-symlink": "^1.0.0",
+        "fast-ordered-set": "^1.0.2",
+        "fs-tree-diff": "^0.5.4",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0"
       }
     },
     "broccoli-persistent-filter": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
       "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g==",
+      "dev": true,
       "requires": {
-        "async-disk-cache": "1.3.2",
-        "async-promise-queue": "1.0.4",
-        "broccoli-plugin": "1.3.0",
-        "fs-tree-diff": "0.5.6",
-        "hash-for-dep": "1.2.0",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "mkdirp": "0.5.1",
-        "promise-map-series": "0.2.3",
-        "rimraf": "2.6.2",
-        "rsvp": "3.6.2",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
+        "async-disk-cache": "^1.2.1",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^1.0.0",
+        "fs-tree-diff": "^0.5.2",
+        "hash-for-dep": "^1.0.2",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^2.6.1",
+        "rsvp": "^3.0.18",
+        "symlink-or-copy": "^1.0.1",
+        "walk-sync": "^0.3.1"
       }
     },
     "broccoli-plugin": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
       "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
+      "dev": true,
       "requires": {
-        "promise-map-series": "0.2.3",
-        "quick-temp": "0.1.8",
-        "rimraf": "2.6.2",
-        "symlink-or-copy": "1.1.8"
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
       }
     },
     "broccoli-source": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
+      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
+      "dev": true
     },
     "broccoli-stew": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.5.0.tgz",
       "integrity": "sha1-16+MGFEdzlEOSdMIpi5Zd/RhiDw=",
+      "dev": true,
       "requires": {
-        "broccoli-debug": "0.6.3",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-persistent-filter": "1.4.3",
-        "broccoli-plugin": "1.3.0",
-        "chalk": "1.1.3",
-        "debug": "2.6.8",
-        "ensure-posix-path": "1.0.2",
-        "fs-extra": "2.1.2",
-        "minimatch": "3.0.4",
-        "resolve": "1.4.0",
-        "rsvp": "3.6.2",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
+        "broccoli-debug": "^0.6.1",
+        "broccoli-funnel": "^1.0.1",
+        "broccoli-merge-trees": "^1.0.0",
+        "broccoli-persistent-filter": "^1.1.6",
+        "broccoli-plugin": "^1.3.0",
+        "chalk": "^1.1.3",
+        "debug": "^2.4.0",
+        "ensure-posix-path": "^1.0.1",
+        "fs-extra": "^2.0.0",
+        "minimatch": "^3.0.2",
+        "resolve": "^1.1.6",
+        "rsvp": "^3.0.16",
+        "symlink-or-copy": "^1.1.8",
+        "walk-sync": "^0.3.0"
       }
     },
     "broccoli-string-replace": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz",
       "integrity": "sha1-HtkvhWgK+NUDAjkl51Tk4zZ2uR8=",
+      "dev": true,
       "requires": {
-        "broccoli-persistent-filter": "1.4.3",
-        "minimatch": "3.0.4"
+        "broccoli-persistent-filter": "^1.1.5",
+        "minimatch": "^3.0.3"
       }
     },
     "broccoli-unwatched-tree": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/broccoli-unwatched-tree/-/broccoli-unwatched-tree-0.1.3.tgz",
       "integrity": "sha1-qw+4IPYThFv2eoA7qtgg9oseOq4=",
+      "dev": true,
       "requires": {
-        "broccoli-source": "1.1.0"
-      }
-    },
-    "broccoli-writer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
-      "integrity": "sha1-1NcaqPKvvGejhmuRotp5CEuWqy0=",
-      "requires": {
-        "quick-temp": "0.1.8",
-        "rsvp": "3.6.2"
+        "broccoli-source": "^1.1.0"
       }
     },
     "browserslist": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.4.0.tgz",
-      "integrity": "sha512-aM2Gt4x9bVlCUteADBS6JP0F+2tMWKM1jQzUulVROtdFWFIcIVvY76AJbr7GDqy0eDhn+PcnpzzivGxY4qiaKQ==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+      "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000732",
-        "electron-to-chromium": "1.3.21"
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-shims": {
       "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
@@ -1438,6 +1941,21 @@
       "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
       "dev": true
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
     "camelcase": {
       "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
@@ -1448,14 +1966,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
       "integrity": "sha1-l7YH2KhLtsbiKLkC2GTstZS50hk=",
+      "dev": true,
       "requires": {
         "tmp": "0.0.28"
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000732",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000732.tgz",
-      "integrity": "sha1-fPnKVl9NMaSz36bia3LsIukCfaE="
+      "version": "1.0.30000878",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000878.tgz",
+      "integrity": "sha512-/dCGTdLCnjVJno1mFRn7Y6eit3AYaeFzSrMQHCoK0LEQaWl5snuLex1Ky4b8/Qu2ig5NgTX4cJx65hH9546puA==",
+      "dev": true
     },
     "center-align": {
       "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -1463,21 +1983,49 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
     "cliui": {
       "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -1485,15 +2033,37 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-        "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
       }
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "dev": true
     },
     "colors": {
       "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
@@ -1504,28 +2074,54 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+      "dev": true
     },
     "core-js": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
     },
     "core-util-is": {
       "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
-      "optional": true
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
     },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1542,12 +2138,34 @@
       "dev": true,
       "optional": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "dezalgo": {
@@ -1556,8 +2174,17 @@
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "requires": {
-        "asap": "2.0.6",
-        "wrappy": "1.0.2"
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
       }
     },
     "ecc-jsbn": {
@@ -1566,18 +2193,20 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+        "jsbn": "~0.1.0"
       }
     },
     "editions": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
-      "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls="
+      "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls=",
+      "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.21",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz",
-      "integrity": "sha1-qWfr3P6O0Ag/wkTRiUAiqOgRPqI="
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.59.tgz",
+      "integrity": "sha512-PbJGGpDSNn3fyUN1eQESAmnMT+a1QAO4NEZgikDuGOn7tbAuMHF87jNna+NoVsMBfEEYzfpn/ay88HgDCJUbQA==",
+      "dev": true
     },
     "ember-ajax": {
       "version": "2.5.2",
@@ -1585,7 +2214,7 @@
       "integrity": "sha1-rv1vhgsDq3XJfnPtQQqp43HqiMY=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "5.1.10"
+        "ember-cli-babel": "^5.1.5"
       }
     },
     "ember-bootstrap": {
@@ -1594,12 +2223,12 @@
       "integrity": "sha1-gQ2ecgLPtUOdcxNgWJpiFECH6Ww=",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "1.1.0",
-        "broccoli-merge-trees": "1.2.1",
-        "ember-cli-babel": "5.1.10",
-        "ember-cli-htmlbars": "1.1.1",
-        "ember-runtime-enumerable-includes-polyfill": "1.0.4",
-        "ember-wormhole": "0.4.1"
+        "broccoli-funnel": "^1.0.1",
+        "broccoli-merge-trees": "^1.1.1",
+        "ember-cli-babel": "^5.1.6",
+        "ember-cli-htmlbars": "^1.1.0",
+        "ember-runtime-enumerable-includes-polyfill": "^1.0.1",
+        "ember-wormhole": "^0.4.1"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -1608,20 +2237,20 @@
           "integrity": "sha1-37kaN8kCRWRW3kpAoYgZSNZbJ9k=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.3.3",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "minimatch": "3.0.3",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.1"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "array-equal": {
@@ -1642,10 +2271,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "promise-map-series": {
@@ -1654,7 +2283,7 @@
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -1671,9 +2300,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -1727,7 +2356,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               }
             },
             "fs-tree-diff": {
@@ -1736,10 +2365,10 @@
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "dev": true,
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "heimdalljs-logger": {
@@ -1748,8 +2377,8 @@
                   "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
+                    "debug": "^2.2.0",
+                    "heimdalljs": "^0.2.0"
                   }
                 },
                 "object-assign": {
@@ -1766,7 +2395,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -1783,7 +2412,7 @@
               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -1792,7 +2421,7 @@
                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.4.2",
+                    "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -1841,7 +2470,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -1850,12 +2479,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -1870,8 +2499,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -1894,7 +2523,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -1927,8 +2556,8 @@
               "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
               "dev": true,
               "requires": {
-                "ensure-posix-path": "1.0.2",
-                "matcher-collection": "1.0.4"
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
               },
               "dependencies": {
                 "ensure-posix-path": {
@@ -1943,7 +2572,7 @@
                   "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                   "dev": true,
                   "requires": {
-                    "minimatch": "3.0.3"
+                    "minimatch": "^3.0.2"
                   }
                 }
               }
@@ -1956,14 +2585,14 @@
           "integrity": "sha1-FqdJTtVtvmFhH2wtSBfPuq0qMFU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "heimdalljs-logger": "0.1.7",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           },
           "dependencies": {
             "broccoli-plugin": {
@@ -1972,10 +2601,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "promise-map-series": {
@@ -1984,7 +2613,7 @@
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -2001,9 +2630,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -2043,7 +2672,7 @@
                   "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
                   "dev": true,
                   "requires": {
-                    "os-tmpdir": "1.0.2"
+                    "os-tmpdir": "~1.0.1"
                   },
                   "dependencies": {
                     "os-tmpdir": {
@@ -2062,7 +2691,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               },
               "dependencies": {
                 "blank-object": {
@@ -2079,10 +2708,10 @@
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "dev": true,
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "object-assign": {
@@ -2105,7 +2734,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -2122,8 +2751,8 @@
               "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3",
-                "heimdalljs": "0.2.3"
+                "debug": "^2.2.0",
+                "heimdalljs": "^0.2.0"
               },
               "dependencies": {
                 "debug": {
@@ -2151,7 +2780,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -2160,12 +2789,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -2180,8 +2809,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -2204,7 +2833,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -2213,7 +2842,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -2239,7 +2868,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -2274,8 +2903,8 @@
           "integrity": "sha1-FqdhLjR6Lt8H2osvLwnb/ucN66A=",
           "dev": true,
           "requires": {
-            "ember-cli-babel": "5.1.10",
-            "ember-cli-version-checker": "1.2.0"
+            "ember-cli-babel": "^5.1.6",
+            "ember-cli-version-checker": "^1.1.6"
           },
           "dependencies": {
             "ember-cli-version-checker": {
@@ -2284,7 +2913,7 @@
               "integrity": "sha1-yqKGt30bSF310vYsZ6bxmqi1gsQ=",
               "dev": true,
               "requires": {
-                "semver": "5.3.0"
+                "semver": "^5.3.0"
               },
               "dependencies": {
                 "semver": {
@@ -2303,8 +2932,8 @@
           "integrity": "sha1-Vfr6rSCmUNIfZYOg5ZwGCmUzgRE=",
           "dev": true,
           "requires": {
-            "ember-cli-babel": "5.1.10",
-            "ember-cli-htmlbars": "1.1.1"
+            "ember-cli-babel": "^5.1.6",
+            "ember-cli-htmlbars": "^1.0.3"
           }
         }
       }
@@ -2316,78 +2945,78 @@
       "dev": true,
       "requires": {
         "amd-name-resolver": "0.0.5",
-        "bower": "1.8.0",
-        "bower-config": "1.4.0",
+        "bower": "^1.3.12",
+        "bower-config": "^1.3.0",
         "bower-endpoint-parser": "0.2.2",
-        "broccoli-babel-transpiler": "5.6.1",
-        "broccoli-concat": "2.3.8",
-        "broccoli-config-loader": "1.0.0",
-        "broccoli-config-replace": "1.1.2",
-        "broccoli-funnel": "1.1.0",
-        "broccoli-funnel-reducer": "1.0.0",
-        "broccoli-merge-trees": "1.2.1",
-        "broccoli-sane-watcher": "1.1.5",
-        "broccoli-source": "1.1.0",
-        "broccoli-viz": "2.0.1",
-        "chalk": "1.1.3",
-        "clean-base-url": "1.0.0",
-        "compression": "1.6.2",
-        "configstore": "2.1.0",
-        "core-object": "2.0.6",
-        "debug": "2.3.3",
-        "diff": "2.2.3",
+        "broccoli-babel-transpiler": "^5.4.5",
+        "broccoli-concat": "^2.0.4",
+        "broccoli-config-loader": "^1.0.0",
+        "broccoli-config-replace": "^1.1.2",
+        "broccoli-funnel": "^1.0.0",
+        "broccoli-funnel-reducer": "^1.0.0",
+        "broccoli-merge-trees": "^1.0.0",
+        "broccoli-sane-watcher": "^1.1.1",
+        "broccoli-source": "^1.1.0",
+        "broccoli-viz": "^2.0.1",
+        "chalk": "^1.1.3",
+        "clean-base-url": "^1.0.0",
+        "compression": "^1.4.4",
+        "configstore": "^2.0.0",
+        "core-object": "^2.0.2",
+        "debug": "^2.1.3",
+        "diff": "^2.2.2",
         "ember-cli-broccoli": "0.16.9",
-        "ember-cli-get-component-path-option": "1.0.0",
-        "ember-cli-is-package-missing": "1.0.0",
-        "ember-cli-legacy-blueprints": "0.1.3",
-        "ember-cli-normalize-entity-name": "1.0.0",
-        "ember-cli-preprocess-registry": "2.0.0",
-        "ember-cli-string-utils": "1.0.0",
-        "ember-try": "0.2.8",
-        "escape-string-regexp": "1.0.5",
-        "exists-sync": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
-        "exit": "0.1.2",
-        "express": "4.14.0",
-        "filesize": "3.3.0",
-        "find-up": "1.1.2",
+        "ember-cli-get-component-path-option": "^1.0.0",
+        "ember-cli-is-package-missing": "^1.0.0",
+        "ember-cli-legacy-blueprints": "^0.1.1",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-preprocess-registry": "^2.0.0",
+        "ember-cli-string-utils": "^1.0.0",
+        "ember-try": "^0.2.2",
+        "escape-string-regexp": "^1.0.3",
+        "exists-sync": "0.0.3",
+        "exit": "^0.1.2",
+        "express": "^4.12.3",
+        "filesize": "^3.1.3",
+        "find-up": "^1.1.2",
         "fs-extra": "0.30.0",
-        "fs-monitor-stack": "1.1.1",
-        "fs-tree-diff": "0.4.4",
-        "get-caller-file": "1.0.2",
-        "git-repo-info": "1.3.1",
+        "fs-monitor-stack": "^1.0.2",
+        "fs-tree-diff": "^0.4.4",
+        "get-caller-file": "^1.0.0",
+        "git-repo-info": "^1.0.4",
         "glob": "7.0.3",
-        "http-proxy": "1.16.1",
-        "inflection": "1.10.0",
-        "inquirer": "0.12.0",
-        "is-git-url": "0.2.3",
-        "isbinaryfile": "3.0.1",
+        "http-proxy": "^1.9.0",
+        "inflection": "^1.7.0",
+        "inquirer": "^0.12.0",
+        "is-git-url": "^0.2.0",
+        "isbinaryfile": "^3.0.0",
         "leek": "0.0.21",
-        "lodash": "4.17.2",
+        "lodash": "^4.12.0",
         "markdown-it": "6.0.4",
         "markdown-it-terminal": "0.0.3",
-        "minimatch": "3.0.3",
-        "morgan": "1.7.0",
-        "node-modules-path": "1.0.1",
-        "node-uuid": "1.4.7",
-        "nopt": "3.0.6",
+        "minimatch": "^3.0.0",
+        "morgan": "^1.5.2",
+        "node-modules-path": "^1.0.0",
+        "node-uuid": "^1.4.3",
+        "nopt": "^3.0.1",
         "npm": "2.15.5",
-        "npm-package-arg": "4.2.0",
-        "ora": "0.2.3",
-        "portfinder": "1.0.10",
-        "promise-map-series": "0.2.3",
+        "npm-package-arg": "^4.1.1",
+        "ora": "^0.2.0",
+        "portfinder": "^1.0.3",
+        "promise-map-series": "^0.2.1",
         "quick-temp": "0.1.5",
-        "resolve": "1.1.7",
-        "rsvp": "3.3.3",
-        "sane": "1.4.1",
-        "semver": "5.3.0",
-        "silent-error": "1.0.1",
-        "symlink-or-copy": "1.1.8",
+        "resolve": "^1.1.6",
+        "rsvp": "^3.0.17",
+        "sane": "^1.1.1",
+        "semver": "^5.1.0",
+        "silent-error": "^1.0.0",
+        "symlink-or-copy": "^1.0.1",
         "temp": "0.8.3",
-        "testem": "1.13.0",
-        "through": "2.3.8",
+        "testem": "^1.8.1",
+        "through": "^2.3.6",
         "tiny-lr": "0.2.1",
-        "tree-sync": "1.1.5",
-        "walk-sync": "0.2.7",
+        "tree-sync": "^1.1.0",
+        "walk-sync": "^0.2.6",
         "yam": "0.0.19"
       },
       "dependencies": {
@@ -2397,7 +3026,7 @@
           "integrity": "sha1-dpYtrIdu0zEbBdKcaljBTh7zMEs=",
           "dev": true,
           "requires": {
-            "ensure-posix-path": "1.0.2"
+            "ensure-posix-path": "^1.0.1"
           },
           "dependencies": {
             "ensure-posix-path": {
@@ -2420,11 +3049,11 @@
           "integrity": "sha1-FsOMETX4BxwZ8lk41hsNjL8Y0/E=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "mout": "1.0.0",
-            "optimist": "0.6.1",
-            "osenv": "0.1.3",
-            "untildify": "2.1.0"
+            "graceful-fs": "^4.1.3",
+            "mout": "^1.0.0",
+            "optimist": "^0.6.1",
+            "osenv": "^0.1.3",
+            "untildify": "^2.1.0"
           },
           "dependencies": {
             "graceful-fs": {
@@ -2445,8 +3074,8 @@
               "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
               "dev": true,
               "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
               },
               "dependencies": {
                 "minimist": {
@@ -2469,8 +3098,8 @@
               "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
               "dev": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               },
               "dependencies": {
                 "os-homedir": {
@@ -2493,7 +3122,7 @@
               "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
               "dev": true,
               "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
               },
               "dependencies": {
                 "os-homedir": {
@@ -2518,13 +3147,13 @@
           "integrity": "sha1-lxhNyxQLQKpX8/84Mwr8zGddCjw=",
           "dev": true,
           "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.1.0",
-            "broccoli-merge-trees": "1.2.1",
-            "broccoli-persistent-filter": "1.2.11",
-            "clone": "0.2.0",
-            "hash-for-dep": "1.0.3",
-            "json-stable-stringify": "1.0.1"
+            "babel-core": "^5.0.0",
+            "broccoli-funnel": "^1.0.0",
+            "broccoli-merge-trees": "^1.0.0",
+            "broccoli-persistent-filter": "^1.0.1",
+            "clone": "^0.2.0",
+            "hash-for-dep": "^1.0.2",
+            "json-stable-stringify": "^1.0.0"
           },
           "dependencies": {
             "babel-core": {
@@ -2533,52 +3162,52 @@
               "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
               "dev": true,
               "requires": {
-                "babel-plugin-constant-folding": "1.0.1",
-                "babel-plugin-dead-code-elimination": "1.0.2",
-                "babel-plugin-eval": "1.0.1",
-                "babel-plugin-inline-environment-variables": "1.0.1",
-                "babel-plugin-jscript": "1.0.4",
-                "babel-plugin-member-expression-literals": "1.0.1",
-                "babel-plugin-property-literals": "1.0.1",
-                "babel-plugin-proto-to-assign": "1.0.4",
-                "babel-plugin-react-constant-elements": "1.0.3",
-                "babel-plugin-react-display-name": "1.0.3",
-                "babel-plugin-remove-console": "1.0.1",
-                "babel-plugin-remove-debugger": "1.0.1",
-                "babel-plugin-runtime": "1.0.7",
-                "babel-plugin-undeclared-variables-check": "1.0.2",
-                "babel-plugin-undefined-to-void": "1.1.6",
-                "babylon": "5.8.38",
-                "bluebird": "2.11.0",
-                "chalk": "1.1.3",
-                "convert-source-map": "1.3.0",
-                "core-js": "1.2.7",
-                "debug": "2.3.3",
-                "detect-indent": "3.0.1",
-                "esutils": "2.0.2",
-                "fs-readdir-recursive": "0.1.2",
-                "globals": "6.4.1",
-                "home-or-tmp": "1.0.0",
-                "is-integer": "1.0.6",
+                "babel-plugin-constant-folding": "^1.0.1",
+                "babel-plugin-dead-code-elimination": "^1.0.2",
+                "babel-plugin-eval": "^1.0.1",
+                "babel-plugin-inline-environment-variables": "^1.0.1",
+                "babel-plugin-jscript": "^1.0.4",
+                "babel-plugin-member-expression-literals": "^1.0.1",
+                "babel-plugin-property-literals": "^1.0.1",
+                "babel-plugin-proto-to-assign": "^1.0.3",
+                "babel-plugin-react-constant-elements": "^1.0.3",
+                "babel-plugin-react-display-name": "^1.0.3",
+                "babel-plugin-remove-console": "^1.0.1",
+                "babel-plugin-remove-debugger": "^1.0.1",
+                "babel-plugin-runtime": "^1.0.7",
+                "babel-plugin-undeclared-variables-check": "^1.0.2",
+                "babel-plugin-undefined-to-void": "^1.1.6",
+                "babylon": "^5.8.38",
+                "bluebird": "^2.9.33",
+                "chalk": "^1.0.0",
+                "convert-source-map": "^1.1.0",
+                "core-js": "^1.0.0",
+                "debug": "^2.1.1",
+                "detect-indent": "^3.0.0",
+                "esutils": "^2.0.0",
+                "fs-readdir-recursive": "^0.1.0",
+                "globals": "^6.4.0",
+                "home-or-tmp": "^1.0.0",
+                "is-integer": "^1.0.4",
                 "js-tokens": "1.0.1",
-                "json5": "0.4.0",
-                "lodash": "3.10.1",
-                "minimatch": "2.0.10",
-                "output-file-sync": "1.1.2",
-                "path-exists": "1.0.0",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.6",
+                "json5": "^0.4.0",
+                "lodash": "^3.10.0",
+                "minimatch": "^2.0.3",
+                "output-file-sync": "^1.1.0",
+                "path-exists": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "private": "^0.1.6",
                 "regenerator": "0.8.40",
-                "regexpu": "1.3.0",
-                "repeating": "1.1.3",
-                "resolve": "1.1.7",
-                "shebang-regex": "1.0.0",
-                "slash": "1.0.0",
-                "source-map": "0.5.6",
-                "source-map-support": "0.2.10",
-                "to-fast-properties": "1.0.2",
-                "trim-right": "1.0.1",
-                "try-resolve": "1.0.1"
+                "regexpu": "^1.3.0",
+                "repeating": "^1.1.2",
+                "resolve": "^1.1.6",
+                "shebang-regex": "^1.0.0",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.0",
+                "source-map-support": "^0.2.10",
+                "to-fast-properties": "^1.0.0",
+                "trim-right": "^1.0.0",
+                "try-resolve": "^1.0.0"
               },
               "dependencies": {
                 "babel-plugin-constant-folding": {
@@ -2629,7 +3258,7 @@
                   "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
                   "dev": true,
                   "requires": {
-                    "lodash": "3.10.1"
+                    "lodash": "^3.9.3"
                   }
                 },
                 "babel-plugin-react-constant-elements": {
@@ -2668,7 +3297,7 @@
                   "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
                   "dev": true,
                   "requires": {
-                    "leven": "1.0.2"
+                    "leven": "^1.0.2"
                   },
                   "dependencies": {
                     "leven": {
@@ -2715,9 +3344,9 @@
                   "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
                   "dev": true,
                   "requires": {
-                    "get-stdin": "4.0.1",
-                    "minimist": "1.2.0",
-                    "repeating": "1.1.3"
+                    "get-stdin": "^4.0.1",
+                    "minimist": "^1.1.0",
+                    "repeating": "^1.1.0"
                   },
                   "dependencies": {
                     "get-stdin": {
@@ -2758,8 +3387,8 @@
                   "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
                   "dev": true,
                   "requires": {
-                    "os-tmpdir": "1.0.2",
-                    "user-home": "1.1.1"
+                    "os-tmpdir": "^1.0.1",
+                    "user-home": "^1.1.1"
                   },
                   "dependencies": {
                     "os-tmpdir": {
@@ -2782,7 +3411,7 @@
                   "integrity": "sha1-UnOBn62ogNEj4awAqTjnFy3Y2V4=",
                   "dev": true,
                   "requires": {
-                    "is-finite": "1.0.2"
+                    "is-finite": "^1.0.0"
                   },
                   "dependencies": {
                     "is-finite": {
@@ -2791,7 +3420,7 @@
                       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
                       "dev": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -2828,7 +3457,7 @@
                   "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.6"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -2837,7 +3466,7 @@
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -2863,9 +3492,9 @@
                   "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11",
-                    "mkdirp": "0.5.1",
-                    "object-assign": "4.1.0"
+                    "graceful-fs": "^4.1.4",
+                    "mkdirp": "^0.5.1",
+                    "object-assign": "^4.1.0"
                   },
                   "dependencies": {
                     "graceful-fs": {
@@ -2923,12 +3552,12 @@
                   "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
                   "dev": true,
                   "requires": {
-                    "commoner": "0.10.8",
-                    "defs": "1.1.1",
-                    "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                    "private": "0.1.6",
+                    "commoner": "~0.10.3",
+                    "defs": "~1.1.0",
+                    "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                    "private": "~0.1.5",
                     "recast": "0.10.33",
-                    "through": "2.3.8"
+                    "through": "~2.3.8"
                   },
                   "dependencies": {
                     "commoner": {
@@ -2937,15 +3566,15 @@
                       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
                       "dev": true,
                       "requires": {
-                        "commander": "2.9.0",
-                        "detective": "4.3.2",
-                        "glob": "5.0.15",
-                        "graceful-fs": "4.1.11",
-                        "iconv-lite": "0.4.15",
-                        "mkdirp": "0.5.1",
-                        "private": "0.1.6",
-                        "q": "1.4.1",
-                        "recast": "0.11.18"
+                        "commander": "^2.5.0",
+                        "detective": "^4.3.1",
+                        "glob": "^5.0.15",
+                        "graceful-fs": "^4.1.2",
+                        "iconv-lite": "^0.4.5",
+                        "mkdirp": "^0.5.0",
+                        "private": "^0.1.6",
+                        "q": "^1.1.2",
+                        "recast": "^0.11.17"
                       },
                       "dependencies": {
                         "commander": {
@@ -2954,7 +3583,7 @@
                           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                           "dev": true,
                           "requires": {
-                            "graceful-readlink": "1.0.1"
+                            "graceful-readlink": ">= 1.0.0"
                           },
                           "dependencies": {
                             "graceful-readlink": {
@@ -2971,8 +3600,8 @@
                           "integrity": "sha1-d2l+LnlHrD/nyOJqbW8RUjWvqRw=",
                           "dev": true,
                           "requires": {
-                            "acorn": "3.3.0",
-                            "defined": "1.0.0"
+                            "acorn": "^3.1.0",
+                            "defined": "^1.0.0"
                           },
                           "dependencies": {
                             "acorn": {
@@ -2995,11 +3624,11 @@
                           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                           "dev": true,
                           "requires": {
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "2.0.10",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "2 || 3",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "inflight": {
@@ -3008,8 +3637,8 @@
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "dev": true,
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -3032,7 +3661,7 @@
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "dev": true,
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -3087,9 +3716,9 @@
                           "dev": true,
                           "requires": {
                             "ast-types": "0.9.2",
-                            "esprima": "3.1.2",
-                            "private": "0.1.6",
-                            "source-map": "0.5.6"
+                            "esprima": "~3.1.0",
+                            "private": "~0.1.5",
+                            "source-map": "~0.5.0"
                           },
                           "dependencies": {
                             "ast-types": {
@@ -3114,16 +3743,16 @@
                       "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
                       "dev": true,
                       "requires": {
-                        "alter": "0.2.0",
-                        "ast-traverse": "0.1.1",
-                        "breakable": "1.0.0",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "simple-fmt": "0.1.0",
-                        "simple-is": "0.2.0",
-                        "stringmap": "0.2.2",
-                        "stringset": "0.2.1",
-                        "tryor": "0.1.2",
-                        "yargs": "3.27.0"
+                        "alter": "~0.2.0",
+                        "ast-traverse": "~0.1.1",
+                        "breakable": "~1.0.0",
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "simple-fmt": "~0.1.0",
+                        "simple-is": "~0.2.0",
+                        "stringmap": "~0.2.2",
+                        "stringset": "~0.2.1",
+                        "tryor": "~0.1.2",
+                        "yargs": "~3.27.0"
                       },
                       "dependencies": {
                         "alter": {
@@ -3132,7 +3761,7 @@
                           "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
                           "dev": true,
                           "requires": {
-                            "stable": "0.1.5"
+                            "stable": "~0.1.3"
                           },
                           "dependencies": {
                             "stable": {
@@ -3191,12 +3820,12 @@
                           "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
                           "dev": true,
                           "requires": {
-                            "camelcase": "1.2.1",
-                            "cliui": "2.1.0",
-                            "decamelize": "1.2.0",
-                            "os-locale": "1.4.0",
-                            "window-size": "0.1.4",
-                            "y18n": "3.2.1"
+                            "camelcase": "^1.2.1",
+                            "cliui": "^2.1.0",
+                            "decamelize": "^1.0.0",
+                            "os-locale": "^1.4.0",
+                            "window-size": "^0.1.2",
+                            "y18n": "^3.2.0"
                           },
                           "dependencies": {
                             "camelcase": {
@@ -3211,8 +3840,8 @@
                               "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                               "dev": true,
                               "requires": {
-                                "center-align": "0.1.3",
-                                "right-align": "0.1.3",
+                                "center-align": "^0.1.1",
+                                "right-align": "^0.1.1",
                                 "wordwrap": "0.0.2"
                               },
                               "dependencies": {
@@ -3222,8 +3851,8 @@
                                   "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                                   "dev": true,
                                   "requires": {
-                                    "align-text": "0.1.4",
-                                    "lazy-cache": "1.0.4"
+                                    "align-text": "^0.1.3",
+                                    "lazy-cache": "^1.0.3"
                                   },
                                   "dependencies": {
                                     "align-text": {
@@ -3232,9 +3861,9 @@
                                       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                                       "dev": true,
                                       "requires": {
-                                        "kind-of": "3.0.4",
-                                        "longest": "1.0.1",
-                                        "repeat-string": "1.6.1"
+                                        "kind-of": "^3.0.2",
+                                        "longest": "^1.0.1",
+                                        "repeat-string": "^1.5.2"
                                       },
                                       "dependencies": {
                                         "kind-of": {
@@ -3243,7 +3872,7 @@
                                           "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
                                           "dev": true,
                                           "requires": {
-                                            "is-buffer": "1.1.4"
+                                            "is-buffer": "^1.0.2"
                                           },
                                           "dependencies": {
                                             "is-buffer": {
@@ -3282,7 +3911,7 @@
                                   "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                                   "dev": true,
                                   "requires": {
-                                    "align-text": "0.1.4"
+                                    "align-text": "^0.1.1"
                                   },
                                   "dependencies": {
                                     "align-text": {
@@ -3291,9 +3920,9 @@
                                       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                                       "dev": true,
                                       "requires": {
-                                        "kind-of": "3.0.4",
-                                        "longest": "1.0.1",
-                                        "repeat-string": "1.6.1"
+                                        "kind-of": "^3.0.2",
+                                        "longest": "^1.0.1",
+                                        "repeat-string": "^1.5.2"
                                       },
                                       "dependencies": {
                                         "kind-of": {
@@ -3302,7 +3931,7 @@
                                           "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
                                           "dev": true,
                                           "requires": {
-                                            "is-buffer": "1.1.4"
+                                            "is-buffer": "^1.0.2"
                                           },
                                           "dependencies": {
                                             "is-buffer": {
@@ -3349,7 +3978,7 @@
                               "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
                               "dev": true,
                               "requires": {
-                                "lcid": "1.0.0"
+                                "lcid": "^1.0.0"
                               },
                               "dependencies": {
                                 "lcid": {
@@ -3358,7 +3987,7 @@
                                   "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                                   "dev": true,
                                   "requires": {
-                                    "invert-kv": "1.0.0"
+                                    "invert-kv": "^1.0.0"
                                   },
                                   "dependencies": {
                                     "invert-kv": {
@@ -3400,9 +4029,9 @@
                       "dev": true,
                       "requires": {
                         "ast-types": "0.8.12",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "private": "0.1.6",
-                        "source-map": "0.5.6"
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "private": "~0.1.5",
+                        "source-map": "~0.5.0"
                       },
                       "dependencies": {
                         "ast-types": {
@@ -3421,11 +4050,11 @@
                   "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
                   "dev": true,
                   "requires": {
-                    "esprima": "2.7.3",
-                    "recast": "0.10.43",
-                    "regenerate": "1.3.2",
-                    "regjsgen": "0.2.0",
-                    "regjsparser": "0.1.5"
+                    "esprima": "^2.6.0",
+                    "recast": "^0.10.10",
+                    "regenerate": "^1.2.1",
+                    "regjsgen": "^0.2.0",
+                    "regjsparser": "^0.1.4"
                   },
                   "dependencies": {
                     "esprima": {
@@ -3441,9 +4070,9 @@
                       "dev": true,
                       "requires": {
                         "ast-types": "0.8.15",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "private": "0.1.6",
-                        "source-map": "0.5.6"
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "private": "~0.1.5",
+                        "source-map": "~0.5.0"
                       },
                       "dependencies": {
                         "ast-types": {
@@ -3478,7 +4107,7 @@
                       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
                       "dev": true,
                       "requires": {
-                        "jsesc": "0.5.0"
+                        "jsesc": "~0.5.0"
                       },
                       "dependencies": {
                         "jsesc": {
@@ -3497,7 +4126,7 @@
                   "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
                   "dev": true,
                   "requires": {
-                    "is-finite": "1.0.2"
+                    "is-finite": "^1.0.0"
                   },
                   "dependencies": {
                     "is-finite": {
@@ -3506,7 +4135,7 @@
                       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
                       "dev": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -3552,7 +4181,7 @@
                       "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
                       "dev": true,
                       "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                       },
                       "dependencies": {
                         "amdefine": {
@@ -3591,19 +4220,19 @@
               "integrity": "sha1-lcxrCw6w3M5fjmrhj2o8xFoGv0A=",
               "dev": true,
               "requires": {
-                "async-disk-cache": "1.0.9",
-                "blank-object": "1.0.2",
-                "broccoli-plugin": "1.3.0",
-                "fs-tree-diff": "0.5.5",
-                "hash-for-dep": "1.0.3",
-                "heimdalljs": "0.2.3",
-                "heimdalljs-logger": "0.1.7",
-                "md5-hex": "1.3.0",
-                "mkdirp": "0.5.1",
-                "promise-map-series": "0.2.3",
-                "rsvp": "3.3.3",
-                "symlink-or-copy": "1.1.8",
-                "walk-sync": "0.3.1"
+                "async-disk-cache": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.0.0",
+                "fs-tree-diff": "^0.5.2",
+                "hash-for-dep": "^1.0.2",
+                "heimdalljs": "^0.2.1",
+                "heimdalljs-logger": "^0.1.7",
+                "md5-hex": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "promise-map-series": "^0.2.1",
+                "rsvp": "^3.0.18",
+                "symlink-or-copy": "^1.0.1",
+                "walk-sync": "^0.3.1"
               },
               "dependencies": {
                 "async-disk-cache": {
@@ -3612,11 +4241,11 @@
                   "integrity": "sha1-I7r7gjGE9GNAfkdOjV+HiZ9yymM=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.3.3",
+                    "debug": "^2.1.3",
                     "istextorbinary": "2.1.0",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.5.4",
-                    "rsvp": "3.3.3"
+                    "mkdirp": "^0.5.0",
+                    "rimraf": "^2.5.3",
+                    "rsvp": "^3.0.18"
                   },
                   "dependencies": {
                     "istextorbinary": {
@@ -3625,9 +4254,9 @@
                       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
                       "dev": true,
                       "requires": {
-                        "binaryextensions": "2.0.0",
-                        "editions": "1.3.3",
-                        "textextensions": "2.0.1"
+                        "binaryextensions": "1 || 2",
+                        "editions": "^1.1.1",
+                        "textextensions": "1 || 2"
                       },
                       "dependencies": {
                         "binaryextensions": {
@@ -3656,7 +4285,7 @@
                       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                       "dev": true,
                       "requires": {
-                        "glob": "7.1.1"
+                        "glob": "^7.0.5"
                       },
                       "dependencies": {
                         "glob": {
@@ -3665,12 +4294,12 @@
                           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                           "dev": true,
                           "requires": {
-                            "fs.realpath": "1.0.0",
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "3.0.3",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "fs.realpath": "^1.0.0",
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "^3.0.2",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "fs.realpath": {
@@ -3685,8 +4314,8 @@
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "dev": true,
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -3709,7 +4338,7 @@
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "dev": true,
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -3744,10 +4373,10 @@
                   "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
                   "dev": true,
                   "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.5",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
+                    "promise-map-series": "^0.2.1",
+                    "quick-temp": "^0.1.3",
+                    "rimraf": "^2.3.4",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "rimraf": {
@@ -3756,7 +4385,7 @@
                       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                       "dev": true,
                       "requires": {
-                        "glob": "7.1.1"
+                        "glob": "^7.0.5"
                       },
                       "dependencies": {
                         "glob": {
@@ -3765,12 +4394,12 @@
                           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                           "dev": true,
                           "requires": {
-                            "fs.realpath": "1.0.0",
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "3.0.3",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "fs.realpath": "^1.0.0",
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "^3.0.2",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "fs.realpath": {
@@ -3785,8 +4414,8 @@
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "dev": true,
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -3809,7 +4438,7 @@
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "dev": true,
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -3838,10 +4467,10 @@
                   "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
                   "dev": true,
                   "requires": {
-                    "heimdalljs-logger": "0.1.7",
-                    "object-assign": "4.1.0",
-                    "path-posix": "1.0.0",
-                    "symlink-or-copy": "1.1.8"
+                    "heimdalljs-logger": "^0.1.7",
+                    "object-assign": "^4.1.0",
+                    "path-posix": "^1.0.0",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "object-assign": {
@@ -3864,7 +4493,7 @@
                   "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.2.1"
+                    "rsvp": "~3.2.1"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -3881,8 +4510,8 @@
                   "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
+                    "debug": "^2.2.0",
+                    "heimdalljs": "^0.2.0"
                   }
                 },
                 "md5-hex": {
@@ -3891,7 +4520,7 @@
                   "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
                   "dev": true,
                   "requires": {
-                    "md5-o-matic": "0.1.1"
+                    "md5-o-matic": "^0.1.1"
                   },
                   "dependencies": {
                     "md5-o-matic": {
@@ -3925,8 +4554,8 @@
                   "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
                   "dev": true,
                   "requires": {
-                    "ensure-posix-path": "1.0.2",
-                    "matcher-collection": "1.0.4"
+                    "ensure-posix-path": "^1.0.0",
+                    "matcher-collection": "^1.0.0"
                   },
                   "dependencies": {
                     "ensure-posix-path": {
@@ -3941,7 +4570,7 @@
                       "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                       "dev": true,
                       "requires": {
-                        "minimatch": "3.0.3"
+                        "minimatch": "^3.0.2"
                       }
                     }
                   }
@@ -3960,8 +4589,8 @@
               "integrity": "sha1-tX8YoKzlY4CVFjijs2prc9hhm4s=",
               "dev": true,
               "requires": {
-                "broccoli-kitchen-sink-helpers": "0.3.1",
-                "resolve": "1.1.7"
+                "broccoli-kitchen-sink-helpers": "^0.3.1",
+                "resolve": "^1.1.6"
               },
               "dependencies": {
                 "broccoli-kitchen-sink-helpers": {
@@ -3970,8 +4599,8 @@
                   "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
                   "dev": true,
                   "requires": {
-                    "glob": "5.0.15",
-                    "mkdirp": "0.5.1"
+                    "glob": "^5.0.10",
+                    "mkdirp": "^0.5.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -3980,11 +4609,11 @@
                       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                       "dev": true,
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -3993,8 +4622,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -4017,7 +4646,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -4063,7 +4692,7 @@
               "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "dev": true,
               "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
               },
               "dependencies": {
                 "jsonify": {
@@ -4082,14 +4711,14 @@
           "integrity": "sha1-WQzcwCG7kFtsEh2HwtHVffRKKkg=",
           "dev": true,
           "requires": {
-            "broccoli-caching-writer": "2.3.1",
-            "broccoli-kitchen-sink-helpers": "0.3.1",
-            "broccoli-stew": "1.4.0",
-            "fast-sourcemap-concat": "1.1.0",
-            "fs-extra": "0.30.0",
-            "lodash.merge": "4.6.0",
-            "lodash.omit": "4.5.0",
-            "lodash.uniq": "4.5.0"
+            "broccoli-caching-writer": "^2.3.1",
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "broccoli-stew": "^1.3.3",
+            "fast-sourcemap-concat": "^1.0.1",
+            "fs-extra": "^0.30.0",
+            "lodash.merge": "^4.3.0",
+            "lodash.omit": "^4.1.0",
+            "lodash.uniq": "^4.2.0"
           },
           "dependencies": {
             "broccoli-caching-writer": {
@@ -4098,12 +4727,12 @@
               "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
               "dev": true,
               "requires": {
-                "broccoli-kitchen-sink-helpers": "0.2.9",
+                "broccoli-kitchen-sink-helpers": "^0.2.5",
                 "broccoli-plugin": "1.1.0",
-                "debug": "2.3.3",
-                "rimraf": "2.5.4",
-                "rsvp": "3.3.3",
-                "walk-sync": "0.2.7"
+                "debug": "^2.1.1",
+                "rimraf": "^2.2.8",
+                "rsvp": "^3.0.17",
+                "walk-sync": "^0.2.5"
               },
               "dependencies": {
                 "broccoli-kitchen-sink-helpers": {
@@ -4112,8 +4741,8 @@
                   "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
                   "dev": true,
                   "requires": {
-                    "glob": "5.0.15",
-                    "mkdirp": "0.5.1"
+                    "glob": "^5.0.10",
+                    "mkdirp": "^0.5.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -4122,11 +4751,11 @@
                       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                       "dev": true,
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -4135,8 +4764,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -4159,7 +4788,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -4203,10 +4832,10 @@
                   "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
                   "dev": true,
                   "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.5",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
+                    "promise-map-series": "^0.2.1",
+                    "quick-temp": "^0.1.3",
+                    "rimraf": "^2.3.4",
+                    "symlink-or-copy": "^1.0.1"
                   }
                 },
                 "rimraf": {
@@ -4215,7 +4844,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -4224,12 +4853,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -4244,8 +4873,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -4268,7 +4897,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -4297,8 +4926,8 @@
               "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
               "dev": true,
               "requires": {
-                "glob": "5.0.15",
-                "mkdirp": "0.5.1"
+                "glob": "^5.0.10",
+                "mkdirp": "^0.5.1"
               },
               "dependencies": {
                 "glob": {
@@ -4307,11 +4936,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -4320,8 +4949,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -4344,7 +4973,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -4388,17 +5017,17 @@
               "integrity": "sha1-G9sKGATWKkGdGQq8JqyzyRh4FU0=",
               "dev": true,
               "requires": {
-                "broccoli-funnel": "1.1.0",
-                "broccoli-merge-trees": "1.2.1",
-                "broccoli-persistent-filter": "1.2.11",
-                "chalk": "1.1.3",
-                "debug": "2.3.3",
-                "ensure-posix-path": "1.0.2",
-                "fs-extra": "0.30.0",
-                "minimatch": "3.0.3",
-                "resolve": "1.1.7",
-                "rsvp": "3.3.3",
-                "walk-sync": "0.3.1"
+                "broccoli-funnel": "^1.0.1",
+                "broccoli-merge-trees": "^1.0.0",
+                "broccoli-persistent-filter": "^1.1.6",
+                "chalk": "^1.1.3",
+                "debug": "^2.1.0",
+                "ensure-posix-path": "^1.0.1",
+                "fs-extra": "^0.30.0",
+                "minimatch": "^3.0.2",
+                "resolve": "^1.1.6",
+                "rsvp": "^3.0.16",
+                "walk-sync": "^0.3.0"
               },
               "dependencies": {
                 "broccoli-persistent-filter": {
@@ -4407,19 +5036,19 @@
                   "integrity": "sha1-lcxrCw6w3M5fjmrhj2o8xFoGv0A=",
                   "dev": true,
                   "requires": {
-                    "async-disk-cache": "1.0.9",
-                    "blank-object": "1.0.2",
-                    "broccoli-plugin": "1.3.0",
-                    "fs-tree-diff": "0.5.5",
-                    "hash-for-dep": "1.0.3",
-                    "heimdalljs": "0.2.3",
-                    "heimdalljs-logger": "0.1.7",
-                    "md5-hex": "1.3.0",
-                    "mkdirp": "0.5.1",
-                    "promise-map-series": "0.2.3",
-                    "rsvp": "3.3.3",
-                    "symlink-or-copy": "1.1.8",
-                    "walk-sync": "0.3.1"
+                    "async-disk-cache": "^1.0.0",
+                    "blank-object": "^1.0.1",
+                    "broccoli-plugin": "^1.0.0",
+                    "fs-tree-diff": "^0.5.2",
+                    "hash-for-dep": "^1.0.2",
+                    "heimdalljs": "^0.2.1",
+                    "heimdalljs-logger": "^0.1.7",
+                    "md5-hex": "^1.0.2",
+                    "mkdirp": "^0.5.1",
+                    "promise-map-series": "^0.2.1",
+                    "rsvp": "^3.0.18",
+                    "symlink-or-copy": "^1.0.1",
+                    "walk-sync": "^0.3.1"
                   },
                   "dependencies": {
                     "async-disk-cache": {
@@ -4428,11 +5057,11 @@
                       "integrity": "sha1-I7r7gjGE9GNAfkdOjV+HiZ9yymM=",
                       "dev": true,
                       "requires": {
-                        "debug": "2.3.3",
+                        "debug": "^2.1.3",
                         "istextorbinary": "2.1.0",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.5.4",
-                        "rsvp": "3.3.3"
+                        "mkdirp": "^0.5.0",
+                        "rimraf": "^2.5.3",
+                        "rsvp": "^3.0.18"
                       },
                       "dependencies": {
                         "istextorbinary": {
@@ -4441,9 +5070,9 @@
                           "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
                           "dev": true,
                           "requires": {
-                            "binaryextensions": "2.0.0",
-                            "editions": "1.3.3",
-                            "textextensions": "2.0.1"
+                            "binaryextensions": "1 || 2",
+                            "editions": "^1.1.1",
+                            "textextensions": "1 || 2"
                           },
                           "dependencies": {
                             "binaryextensions": {
@@ -4472,7 +5101,7 @@
                           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                           "dev": true,
                           "requires": {
-                            "glob": "7.1.1"
+                            "glob": "^7.0.5"
                           },
                           "dependencies": {
                             "glob": {
@@ -4481,12 +5110,12 @@
                               "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                               "dev": true,
                               "requires": {
-                                "fs.realpath": "1.0.0",
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.3",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.2",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                               },
                               "dependencies": {
                                 "fs.realpath": {
@@ -4501,8 +5130,8 @@
                                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                                   "dev": true,
                                   "requires": {
-                                    "once": "1.4.0",
-                                    "wrappy": "1.0.2"
+                                    "once": "^1.3.0",
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -4525,7 +5154,7 @@
                                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                                   "dev": true,
                                   "requires": {
-                                    "wrappy": "1.0.2"
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -4560,10 +5189,10 @@
                       "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
                       "dev": true,
                       "requires": {
-                        "promise-map-series": "0.2.3",
-                        "quick-temp": "0.1.5",
-                        "rimraf": "2.5.4",
-                        "symlink-or-copy": "1.1.8"
+                        "promise-map-series": "^0.2.1",
+                        "quick-temp": "^0.1.3",
+                        "rimraf": "^2.3.4",
+                        "symlink-or-copy": "^1.1.8"
                       },
                       "dependencies": {
                         "rimraf": {
@@ -4572,7 +5201,7 @@
                           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                           "dev": true,
                           "requires": {
-                            "glob": "7.1.1"
+                            "glob": "^7.0.5"
                           },
                           "dependencies": {
                             "glob": {
@@ -4581,12 +5210,12 @@
                               "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                               "dev": true,
                               "requires": {
-                                "fs.realpath": "1.0.0",
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.3",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.2",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                               },
                               "dependencies": {
                                 "fs.realpath": {
@@ -4601,8 +5230,8 @@
                                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                                   "dev": true,
                                   "requires": {
-                                    "once": "1.4.0",
-                                    "wrappy": "1.0.2"
+                                    "once": "^1.3.0",
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -4625,7 +5254,7 @@
                                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                                   "dev": true,
                                   "requires": {
-                                    "wrappy": "1.0.2"
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -4654,10 +5283,10 @@
                       "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
                       "dev": true,
                       "requires": {
-                        "heimdalljs-logger": "0.1.7",
-                        "object-assign": "4.1.0",
-                        "path-posix": "1.0.0",
-                        "symlink-or-copy": "1.1.8"
+                        "heimdalljs-logger": "^0.1.7",
+                        "object-assign": "^4.1.0",
+                        "path-posix": "^1.0.0",
+                        "symlink-or-copy": "^1.1.8"
                       },
                       "dependencies": {
                         "object-assign": {
@@ -4680,8 +5309,8 @@
                       "integrity": "sha1-tX8YoKzlY4CVFjijs2prc9hhm4s=",
                       "dev": true,
                       "requires": {
-                        "broccoli-kitchen-sink-helpers": "0.3.1",
-                        "resolve": "1.1.7"
+                        "broccoli-kitchen-sink-helpers": "^0.3.1",
+                        "resolve": "^1.1.6"
                       }
                     },
                     "heimdalljs": {
@@ -4690,7 +5319,7 @@
                       "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
                       "dev": true,
                       "requires": {
-                        "rsvp": "3.2.1"
+                        "rsvp": "~3.2.1"
                       },
                       "dependencies": {
                         "rsvp": {
@@ -4707,8 +5336,8 @@
                       "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                       "dev": true,
                       "requires": {
-                        "debug": "2.3.3",
-                        "heimdalljs": "0.2.3"
+                        "debug": "^2.2.0",
+                        "heimdalljs": "^0.2.0"
                       }
                     },
                     "md5-hex": {
@@ -4717,7 +5346,7 @@
                       "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
                       "dev": true,
                       "requires": {
-                        "md5-o-matic": "0.1.1"
+                        "md5-o-matic": "^0.1.1"
                       },
                       "dependencies": {
                         "md5-o-matic": {
@@ -4759,8 +5388,8 @@
                   "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
                   "dev": true,
                   "requires": {
-                    "ensure-posix-path": "1.0.2",
-                    "matcher-collection": "1.0.4"
+                    "ensure-posix-path": "^1.0.0",
+                    "matcher-collection": "^1.0.0"
                   },
                   "dependencies": {
                     "matcher-collection": {
@@ -4769,7 +5398,7 @@
                       "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                       "dev": true,
                       "requires": {
-                        "minimatch": "3.0.3"
+                        "minimatch": "^3.0.2"
                       }
                     }
                   }
@@ -4782,14 +5411,14 @@
               "integrity": "sha1-qAB2er7V7aAuZyOOwGOnCb5h+dQ=",
               "dev": true,
               "requires": {
-                "chalk": "0.5.1",
-                "debug": "2.3.3",
-                "fs-extra": "0.30.0",
-                "memory-streams": "0.1.0",
-                "mkdirp": "0.5.1",
-                "rsvp": "3.3.3",
-                "source-map": "0.4.4",
-                "source-map-url": "0.3.0"
+                "chalk": "^0.5.1",
+                "debug": "^2.2.0",
+                "fs-extra": "^0.30.0",
+                "memory-streams": "^0.1.0",
+                "mkdirp": "^0.5.0",
+                "rsvp": "^3.0.14",
+                "source-map": "^0.4.2",
+                "source-map-url": "^0.3.0"
               },
               "dependencies": {
                 "chalk": {
@@ -4798,11 +5427,11 @@
                   "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "1.1.0",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "0.1.0",
-                    "strip-ansi": "0.3.0",
-                    "supports-color": "0.2.0"
+                    "ansi-styles": "^1.1.0",
+                    "escape-string-regexp": "^1.0.0",
+                    "has-ansi": "^0.1.0",
+                    "strip-ansi": "^0.3.0",
+                    "supports-color": "^0.2.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -4817,7 +5446,7 @@
                       "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -4834,7 +5463,7 @@
                       "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.1"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -4859,7 +5488,7 @@
                   "integrity": "sha1-vsZYpx4/KLDwwvGxRQHC21R9X3o=",
                   "dev": true,
                   "requires": {
-                    "readable-stream": "1.0.34"
+                    "readable-stream": "~1.0.2"
                   },
                   "dependencies": {
                     "readable-stream": {
@@ -4868,10 +5497,10 @@
                       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                       "dev": true,
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -4925,7 +5554,7 @@
                   "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                   "dev": true,
                   "requires": {
-                    "amdefine": "1.0.1"
+                    "amdefine": ">=0.0.4"
                   },
                   "dependencies": {
                     "amdefine": {
@@ -4970,7 +5599,7 @@
           "integrity": "sha1-w89ez6/8BDOMbx1dONw2uuqhMbo=",
           "dev": true,
           "requires": {
-            "broccoli-caching-writer": "2.3.1"
+            "broccoli-caching-writer": "^2.0.4"
           },
           "dependencies": {
             "broccoli-caching-writer": {
@@ -4979,12 +5608,12 @@
               "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
               "dev": true,
               "requires": {
-                "broccoli-kitchen-sink-helpers": "0.2.9",
+                "broccoli-kitchen-sink-helpers": "^0.2.5",
                 "broccoli-plugin": "1.1.0",
-                "debug": "2.3.3",
-                "rimraf": "2.5.4",
-                "rsvp": "3.3.3",
-                "walk-sync": "0.2.7"
+                "debug": "^2.1.1",
+                "rimraf": "^2.2.8",
+                "rsvp": "^3.0.17",
+                "walk-sync": "^0.2.5"
               },
               "dependencies": {
                 "broccoli-kitchen-sink-helpers": {
@@ -4993,8 +5622,8 @@
                   "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
                   "dev": true,
                   "requires": {
-                    "glob": "5.0.15",
-                    "mkdirp": "0.5.1"
+                    "glob": "^5.0.10",
+                    "mkdirp": "^0.5.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -5003,11 +5632,11 @@
                       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                       "dev": true,
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -5016,8 +5645,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -5040,7 +5669,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -5084,10 +5713,10 @@
                   "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
                   "dev": true,
                   "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.5",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
+                    "promise-map-series": "^0.2.1",
+                    "quick-temp": "^0.1.3",
+                    "rimraf": "^2.3.4",
+                    "symlink-or-copy": "^1.0.1"
                   }
                 },
                 "rimraf": {
@@ -5096,7 +5725,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -5105,12 +5734,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -5125,8 +5754,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -5149,7 +5778,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -5180,10 +5809,10 @@
           "integrity": "sha1-bqh52SpbrWNNETKbUfxfSq/anAA=",
           "dev": true,
           "requires": {
-            "broccoli-kitchen-sink-helpers": "0.3.1",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.3.3",
-            "fs-extra": "0.24.0"
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "broccoli-plugin": "^1.2.0",
+            "debug": "^2.2.0",
+            "fs-extra": "^0.24.0"
           },
           "dependencies": {
             "broccoli-kitchen-sink-helpers": {
@@ -5192,8 +5821,8 @@
               "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
               "dev": true,
               "requires": {
-                "glob": "5.0.15",
-                "mkdirp": "0.5.1"
+                "glob": "^5.0.10",
+                "mkdirp": "^0.5.1"
               },
               "dependencies": {
                 "glob": {
@@ -5202,11 +5831,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -5215,8 +5844,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -5239,7 +5868,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -5283,10 +5912,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.5",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "rimraf": {
@@ -5295,7 +5924,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -5304,12 +5933,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -5324,8 +5953,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -5348,7 +5977,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -5377,10 +6006,10 @@
               "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "2.4.0",
-                "path-is-absolute": "1.0.1",
-                "rimraf": "2.5.4"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
               },
               "dependencies": {
                 "graceful-fs": {
@@ -5395,7 +6024,7 @@
                   "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11"
+                    "graceful-fs": "^4.1.6"
                   }
                 },
                 "path-is-absolute": {
@@ -5410,7 +6039,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -5419,12 +6048,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -5439,8 +6068,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -5463,7 +6092,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -5488,20 +6117,20 @@
           "integrity": "sha1-37kaN8kCRWRW3kpAoYgZSNZbJ9k=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.3.3",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "minimatch": "3.0.3",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.1"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "array-equal": {
@@ -5522,10 +6151,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.5",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               }
             },
             "exists-sync": {
@@ -5540,7 +6169,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               }
             },
             "fs-tree-diff": {
@@ -5549,10 +6178,10 @@
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "dev": true,
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "heimdalljs-logger": {
@@ -5561,8 +6190,8 @@
                   "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
+                    "debug": "^2.2.0",
+                    "heimdalljs": "^0.2.0"
                   }
                 },
                 "object-assign": {
@@ -5579,7 +6208,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -5619,7 +6248,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -5628,12 +6257,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -5648,8 +6277,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -5672,7 +6301,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -5699,8 +6328,8 @@
               "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
               "dev": true,
               "requires": {
-                "ensure-posix-path": "1.0.2",
-                "matcher-collection": "1.0.4"
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
               },
               "dependencies": {
                 "ensure-posix-path": {
@@ -5715,7 +6344,7 @@
                   "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                   "dev": true,
                   "requires": {
-                    "minimatch": "3.0.3"
+                    "minimatch": "^3.0.2"
                   }
                 }
               }
@@ -5734,14 +6363,14 @@
           "integrity": "sha1-FqdJTtVtvmFhH2wtSBfPuq0qMFU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "heimdalljs-logger": "0.1.7",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           },
           "dependencies": {
             "broccoli-plugin": {
@@ -5750,10 +6379,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.5",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               }
             },
             "can-symlink": {
@@ -5771,7 +6400,7 @@
                   "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
                   "dev": true,
                   "requires": {
-                    "os-tmpdir": "1.0.2"
+                    "os-tmpdir": "~1.0.1"
                   },
                   "dependencies": {
                     "os-tmpdir": {
@@ -5790,7 +6419,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               },
               "dependencies": {
                 "blank-object": {
@@ -5807,10 +6436,10 @@
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "dev": true,
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "object-assign": {
@@ -5833,7 +6462,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -5850,8 +6479,8 @@
               "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3",
-                "heimdalljs": "0.2.3"
+                "debug": "^2.2.0",
+                "heimdalljs": "^0.2.0"
               }
             },
             "rimraf": {
@@ -5860,7 +6489,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -5869,12 +6498,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -5889,8 +6518,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -5913,7 +6542,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -5942,10 +6571,10 @@
           "integrity": "sha1-8rCvnPCvt0x6Sc2I6xHGhp7owMA=",
           "dev": true,
           "requires": {
-            "broccoli-slow-trees": "1.1.0",
-            "debug": "2.3.3",
-            "rsvp": "3.3.3",
-            "sane": "1.4.1"
+            "broccoli-slow-trees": "^1.1.0",
+            "debug": "^2.1.0",
+            "rsvp": "^3.0.18",
+            "sane": "^1.1.1"
           },
           "dependencies": {
             "broccoli-slow-trees": {
@@ -5974,11 +6603,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -5993,7 +6622,7 @@
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -6010,7 +6639,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -6041,12 +6670,12 @@
           "integrity": "sha1-zOsSHsydCcUtetDDNQ6pPd1AK8M=",
           "dev": true,
           "requires": {
-            "accepts": "1.3.3",
+            "accepts": "~1.3.3",
             "bytes": "2.3.0",
-            "compressible": "2.0.9",
-            "debug": "2.2.0",
-            "on-headers": "1.0.1",
-            "vary": "1.1.0"
+            "compressible": "~2.0.8",
+            "debug": "~2.2.0",
+            "on-headers": "~1.0.1",
+            "vary": "~1.1.0"
           },
           "dependencies": {
             "accepts": {
@@ -6055,7 +6684,7 @@
               "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
               "dev": true,
               "requires": {
-                "mime-types": "2.1.13",
+                "mime-types": "~2.1.11",
                 "negotiator": "0.6.1"
               },
               "dependencies": {
@@ -6065,7 +6694,7 @@
                   "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
                   "dev": true,
                   "requires": {
-                    "mime-db": "1.25.0"
+                    "mime-db": "~1.25.0"
                   },
                   "dependencies": {
                     "mime-db": {
@@ -6096,7 +6725,7 @@
               "integrity": "sha1-baq04rWZwncN2eIeeokbHFp1VCU=",
               "dev": true,
               "requires": {
-                "mime-db": "1.25.0"
+                "mime-db": ">= 1.24.0 < 2"
               },
               "dependencies": {
                 "mime-db": {
@@ -6144,15 +6773,15 @@
           "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
           "dev": true,
           "requires": {
-            "dot-prop": "3.0.0",
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.0",
-            "os-tmpdir": "1.0.2",
-            "osenv": "0.1.3",
-            "uuid": "2.0.3",
-            "write-file-atomic": "1.2.0",
-            "xdg-basedir": "2.0.0"
+            "dot-prop": "^3.0.0",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "object-assign": "^4.0.1",
+            "os-tmpdir": "^1.0.0",
+            "osenv": "^0.1.0",
+            "uuid": "^2.0.1",
+            "write-file-atomic": "^1.1.2",
+            "xdg-basedir": "^2.0.0"
           },
           "dependencies": {
             "dot-prop": {
@@ -6161,7 +6790,7 @@
               "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
               "dev": true,
               "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
               },
               "dependencies": {
                 "is-obj": {
@@ -6213,8 +6842,8 @@
               "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
               "dev": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               },
               "dependencies": {
                 "os-homedir": {
@@ -6237,9 +6866,9 @@
               "integrity": "sha1-FMZtTkyzygVlwozzt6bz5NWTj6s=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
+                "graceful-fs": "^4.1.2",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
               },
               "dependencies": {
                 "imurmurhash": {
@@ -6262,7 +6891,7 @@
               "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
               "dev": true,
               "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
               },
               "dependencies": {
                 "os-homedir": {
@@ -6281,7 +6910,7 @@
           "integrity": "sha1-YBNLnED/abJ7wV6C25ReTfeClhs=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.1.3"
           }
         },
         "debug": {
@@ -6313,18 +6942,18 @@
           "integrity": "sha1-TpEo9Z/67plwXAHppEppGgrhmds=",
           "dev": true,
           "requires": {
-            "broccoli-kitchen-sink-helpers": "0.2.9",
-            "broccoli-slow-trees": "1.1.0",
-            "commander": "2.9.0",
-            "connect": "3.5.0",
-            "copy-dereference": "1.0.0",
-            "findup-sync": "0.2.1",
-            "handlebars": "4.0.6",
-            "mime": "1.3.4",
-            "promise-map-series": "0.2.3",
-            "quick-temp": "0.1.5",
-            "rimraf": "2.5.4",
-            "rsvp": "3.3.3"
+            "broccoli-kitchen-sink-helpers": "^0.2.5",
+            "broccoli-slow-trees": "^1.0.0",
+            "commander": "^2.5.0",
+            "connect": "^3.3.3",
+            "copy-dereference": "^1.0.0",
+            "findup-sync": "^0.2.1",
+            "handlebars": "^4.0.4",
+            "mime": "^1.2.11",
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.2",
+            "rimraf": "^2.2.8",
+            "rsvp": "^3.0.17"
           },
           "dependencies": {
             "broccoli-kitchen-sink-helpers": {
@@ -6333,8 +6962,8 @@
               "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
               "dev": true,
               "requires": {
-                "glob": "5.0.15",
-                "mkdirp": "0.5.1"
+                "glob": "^5.0.10",
+                "mkdirp": "^0.5.1"
               },
               "dependencies": {
                 "glob": {
@@ -6343,11 +6972,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -6356,8 +6985,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -6380,7 +7009,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -6430,7 +7059,7 @@
               "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
               "dev": true,
               "requires": {
-                "graceful-readlink": "1.0.1"
+                "graceful-readlink": ">= 1.0.0"
               },
               "dependencies": {
                 "graceful-readlink": {
@@ -6447,9 +7076,9 @@
               "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
               "dev": true,
               "requires": {
-                "debug": "2.2.0",
+                "debug": "~2.2.0",
                 "finalhandler": "0.5.0",
-                "parseurl": "1.3.1",
+                "parseurl": "~1.3.1",
                 "utils-merge": "1.0.0"
               },
               "dependencies": {
@@ -6476,11 +7105,11 @@
                   "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.2.0",
-                    "escape-html": "1.0.3",
-                    "on-finished": "2.3.0",
-                    "statuses": "1.3.1",
-                    "unpipe": "1.0.0"
+                    "debug": "~2.2.0",
+                    "escape-html": "~1.0.3",
+                    "on-finished": "~2.3.0",
+                    "statuses": "~1.3.0",
+                    "unpipe": "~1.0.0"
                   },
                   "dependencies": {
                     "escape-html": {
@@ -6546,7 +7175,7 @@
               "integrity": "sha1-4KkKRQB1xJRm7lE3MgV1FLgeh4w=",
               "dev": true,
               "requires": {
-                "glob": "4.3.5"
+                "glob": "~4.3.0"
               },
               "dependencies": {
                 "glob": {
@@ -6555,10 +7184,10 @@
                   "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "2.0.10",
-                    "once": "1.4.0"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^2.0.1",
+                    "once": "^1.3.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -6567,8 +7196,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -6591,7 +7220,7 @@
                       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -6600,7 +7229,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -6626,7 +7255,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -6647,10 +7276,10 @@
               "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
               },
               "dependencies": {
                 "async": {
@@ -6665,8 +7294,8 @@
                   "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
                   "dev": true,
                   "requires": {
-                    "minimist": "0.0.10",
-                    "wordwrap": "0.0.3"
+                    "minimist": "~0.0.1",
+                    "wordwrap": "~0.0.2"
                   },
                   "dependencies": {
                     "minimist": {
@@ -6689,7 +7318,7 @@
                   "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                   "dev": true,
                   "requires": {
-                    "amdefine": "1.0.1"
+                    "amdefine": ">=0.0.4"
                   },
                   "dependencies": {
                     "amdefine": {
@@ -6714,7 +7343,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -6723,12 +7352,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -6743,8 +7372,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -6767,7 +7396,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -6808,23 +7437,23 @@
           "integrity": "sha1-yvR3p3UimgzWootlkwSUPbE2d3A=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "ember-cli-get-component-path-option": "1.0.0",
-            "ember-cli-get-dependency-depth": "1.0.0",
-            "ember-cli-is-package-missing": "1.0.0",
-            "ember-cli-lodash-subset": "1.0.11",
-            "ember-cli-normalize-entity-name": "1.0.0",
-            "ember-cli-path-utils": "1.0.0",
-            "ember-cli-string-utils": "1.0.0",
-            "ember-cli-test-info": "1.0.0",
-            "ember-cli-valid-component-name": "1.0.0",
-            "ember-cli-version-checker": "1.2.0",
-            "ember-router-generator": "1.2.2",
-            "exists-sync": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
-            "fs-extra": "0.24.0",
-            "inflection": "1.10.0",
-            "rsvp": "3.3.3",
-            "silent-error": "1.0.1"
+            "chalk": "^1.1.1",
+            "ember-cli-get-component-path-option": "^1.0.0",
+            "ember-cli-get-dependency-depth": "^1.0.0",
+            "ember-cli-is-package-missing": "^1.0.0",
+            "ember-cli-lodash-subset": "^1.0.7",
+            "ember-cli-normalize-entity-name": "^1.0.0",
+            "ember-cli-path-utils": "^1.0.0",
+            "ember-cli-string-utils": "^1.0.0",
+            "ember-cli-test-info": "^1.0.0",
+            "ember-cli-valid-component-name": "^1.0.0",
+            "ember-cli-version-checker": "^1.1.7",
+            "ember-router-generator": "^1.0.0",
+            "exists-sync": "0.0.3",
+            "fs-extra": "^0.24.0",
+            "inflection": "^1.7.1",
+            "rsvp": "^3.0.17",
+            "silent-error": "^1.0.0"
           },
           "dependencies": {
             "ember-cli-get-dependency-depth": {
@@ -6851,7 +7480,7 @@
               "integrity": "sha1-7U6WDySel1I8+JHkrtIHLOhFd7Q=",
               "dev": true,
               "requires": {
-                "ember-cli-string-utils": "1.0.0"
+                "ember-cli-string-utils": "^1.0.0"
               }
             },
             "ember-cli-valid-component-name": {
@@ -6860,7 +7489,7 @@
               "integrity": "sha1-cVUM44fgIzBl8wswsVEKot++h+8=",
               "dev": true,
               "requires": {
-                "silent-error": "1.0.1"
+                "silent-error": "^1.0.0"
               }
             },
             "ember-cli-version-checker": {
@@ -6869,7 +7498,7 @@
               "integrity": "sha1-yqKGt30bSF310vYsZ6bxmqi1gsQ=",
               "dev": true,
               "requires": {
-                "semver": "5.3.0"
+                "semver": "^5.3.0"
               }
             },
             "ember-router-generator": {
@@ -6878,7 +7507,7 @@
               "integrity": "sha1-YtrB9j6HNVPm1MfjLaZYnld7z2M=",
               "dev": true,
               "requires": {
-                "recast": "0.11.18"
+                "recast": "^0.11.3"
               },
               "dependencies": {
                 "recast": {
@@ -6888,9 +7517,9 @@
                   "dev": true,
                   "requires": {
                     "ast-types": "0.9.2",
-                    "esprima": "3.1.2",
-                    "private": "0.1.6",
-                    "source-map": "0.5.6"
+                    "esprima": "~3.1.0",
+                    "private": "~0.1.5",
+                    "source-map": "~0.5.0"
                   },
                   "dependencies": {
                     "ast-types": {
@@ -6927,10 +7556,10 @@
               "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "2.4.0",
-                "path-is-absolute": "1.0.1",
-                "rimraf": "2.5.4"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
               },
               "dependencies": {
                 "graceful-fs": {
@@ -6945,7 +7574,7 @@
                   "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11"
+                    "graceful-fs": "^4.1.6"
                   }
                 },
                 "path-is-absolute": {
@@ -6960,7 +7589,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -6969,12 +7598,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -6989,8 +7618,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -7013,7 +7642,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -7038,7 +7667,7 @@
           "integrity": "sha1-CxT3vLxZmqEXtf3cgeT9A8S61bc=",
           "dev": true,
           "requires": {
-            "silent-error": "1.0.1"
+            "silent-error": "^1.0.0"
           }
         },
         "ember-cli-preprocess-registry": {
@@ -7047,14 +7676,14 @@
           "integrity": "sha1-Rci5heuga7RDs6vOHDxiIP3LgJQ=",
           "dev": true,
           "requires": {
-            "broccoli-clean-css": "1.1.0",
-            "broccoli-funnel": "1.1.0",
-            "broccoli-merge-trees": "1.2.1",
-            "debug": "2.3.3",
-            "exists-sync": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
-            "lodash": "3.10.1",
-            "process-relative-require": "1.0.0",
-            "silent-error": "1.0.1"
+            "broccoli-clean-css": "^1.1.0",
+            "broccoli-funnel": "^1.0.0",
+            "broccoli-merge-trees": "^1.0.0",
+            "debug": "^2.2.0",
+            "exists-sync": "0.0.3",
+            "lodash": "^3.10.0",
+            "process-relative-require": "^1.0.0",
+            "silent-error": "^1.0.0"
           },
           "dependencies": {
             "broccoli-clean-css": {
@@ -7063,10 +7692,10 @@
               "integrity": "sha1-nbFD2a9+CuecJuOsWpuy1yDqGfo=",
               "dev": true,
               "requires": {
-                "broccoli-persistent-filter": "1.2.11",
-                "clean-css-promise": "0.1.1",
-                "inline-source-map-comment": "1.0.5",
-                "json-stable-stringify": "1.0.1"
+                "broccoli-persistent-filter": "^1.1.6",
+                "clean-css-promise": "^0.1.0",
+                "inline-source-map-comment": "^1.0.5",
+                "json-stable-stringify": "^1.0.0"
               },
               "dependencies": {
                 "broccoli-persistent-filter": {
@@ -7075,19 +7704,19 @@
                   "integrity": "sha1-lcxrCw6w3M5fjmrhj2o8xFoGv0A=",
                   "dev": true,
                   "requires": {
-                    "async-disk-cache": "1.0.9",
-                    "blank-object": "1.0.2",
-                    "broccoli-plugin": "1.3.0",
-                    "fs-tree-diff": "0.5.5",
-                    "hash-for-dep": "1.0.3",
-                    "heimdalljs": "0.2.3",
-                    "heimdalljs-logger": "0.1.7",
-                    "md5-hex": "1.3.0",
-                    "mkdirp": "0.5.1",
-                    "promise-map-series": "0.2.3",
-                    "rsvp": "3.3.3",
-                    "symlink-or-copy": "1.1.8",
-                    "walk-sync": "0.3.1"
+                    "async-disk-cache": "^1.0.0",
+                    "blank-object": "^1.0.1",
+                    "broccoli-plugin": "^1.0.0",
+                    "fs-tree-diff": "^0.5.2",
+                    "hash-for-dep": "^1.0.2",
+                    "heimdalljs": "^0.2.1",
+                    "heimdalljs-logger": "^0.1.7",
+                    "md5-hex": "^1.0.2",
+                    "mkdirp": "^0.5.1",
+                    "promise-map-series": "^0.2.1",
+                    "rsvp": "^3.0.18",
+                    "symlink-or-copy": "^1.0.1",
+                    "walk-sync": "^0.3.1"
                   },
                   "dependencies": {
                     "async-disk-cache": {
@@ -7096,11 +7725,11 @@
                       "integrity": "sha1-I7r7gjGE9GNAfkdOjV+HiZ9yymM=",
                       "dev": true,
                       "requires": {
-                        "debug": "2.3.3",
+                        "debug": "^2.1.3",
                         "istextorbinary": "2.1.0",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.5.4",
-                        "rsvp": "3.3.3"
+                        "mkdirp": "^0.5.0",
+                        "rimraf": "^2.5.3",
+                        "rsvp": "^3.0.18"
                       },
                       "dependencies": {
                         "istextorbinary": {
@@ -7109,9 +7738,9 @@
                           "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
                           "dev": true,
                           "requires": {
-                            "binaryextensions": "2.0.0",
-                            "editions": "1.3.3",
-                            "textextensions": "2.0.1"
+                            "binaryextensions": "1 || 2",
+                            "editions": "^1.1.1",
+                            "textextensions": "1 || 2"
                           },
                           "dependencies": {
                             "binaryextensions": {
@@ -7140,7 +7769,7 @@
                           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                           "dev": true,
                           "requires": {
-                            "glob": "7.1.1"
+                            "glob": "^7.0.5"
                           },
                           "dependencies": {
                             "glob": {
@@ -7149,12 +7778,12 @@
                               "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                               "dev": true,
                               "requires": {
-                                "fs.realpath": "1.0.0",
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.3",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.2",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                               },
                               "dependencies": {
                                 "fs.realpath": {
@@ -7169,8 +7798,8 @@
                                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                                   "dev": true,
                                   "requires": {
-                                    "once": "1.4.0",
-                                    "wrappy": "1.0.2"
+                                    "once": "^1.3.0",
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -7193,7 +7822,7 @@
                                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                                   "dev": true,
                                   "requires": {
-                                    "wrappy": "1.0.2"
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -7228,10 +7857,10 @@
                       "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
                       "dev": true,
                       "requires": {
-                        "promise-map-series": "0.2.3",
-                        "quick-temp": "0.1.5",
-                        "rimraf": "2.5.4",
-                        "symlink-or-copy": "1.1.8"
+                        "promise-map-series": "^0.2.1",
+                        "quick-temp": "^0.1.3",
+                        "rimraf": "^2.3.4",
+                        "symlink-or-copy": "^1.1.8"
                       },
                       "dependencies": {
                         "rimraf": {
@@ -7240,7 +7869,7 @@
                           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                           "dev": true,
                           "requires": {
-                            "glob": "7.1.1"
+                            "glob": "^7.0.5"
                           },
                           "dependencies": {
                             "glob": {
@@ -7249,12 +7878,12 @@
                               "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                               "dev": true,
                               "requires": {
-                                "fs.realpath": "1.0.0",
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.3",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.2",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                               },
                               "dependencies": {
                                 "fs.realpath": {
@@ -7269,8 +7898,8 @@
                                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                                   "dev": true,
                                   "requires": {
-                                    "once": "1.4.0",
-                                    "wrappy": "1.0.2"
+                                    "once": "^1.3.0",
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -7293,7 +7922,7 @@
                                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                                   "dev": true,
                                   "requires": {
-                                    "wrappy": "1.0.2"
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -7322,10 +7951,10 @@
                       "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
                       "dev": true,
                       "requires": {
-                        "heimdalljs-logger": "0.1.7",
-                        "object-assign": "4.1.0",
-                        "path-posix": "1.0.0",
-                        "symlink-or-copy": "1.1.8"
+                        "heimdalljs-logger": "^0.1.7",
+                        "object-assign": "^4.1.0",
+                        "path-posix": "^1.0.0",
+                        "symlink-or-copy": "^1.1.8"
                       },
                       "dependencies": {
                         "object-assign": {
@@ -7348,8 +7977,8 @@
                       "integrity": "sha1-tX8YoKzlY4CVFjijs2prc9hhm4s=",
                       "dev": true,
                       "requires": {
-                        "broccoli-kitchen-sink-helpers": "0.3.1",
-                        "resolve": "1.1.7"
+                        "broccoli-kitchen-sink-helpers": "^0.3.1",
+                        "resolve": "^1.1.6"
                       },
                       "dependencies": {
                         "broccoli-kitchen-sink-helpers": {
@@ -7358,8 +7987,8 @@
                           "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
                           "dev": true,
                           "requires": {
-                            "glob": "5.0.15",
-                            "mkdirp": "0.5.1"
+                            "glob": "^5.0.10",
+                            "mkdirp": "^0.5.1"
                           },
                           "dependencies": {
                             "glob": {
@@ -7368,11 +7997,11 @@
                               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                               "dev": true,
                               "requires": {
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.3",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "2 || 3",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                               },
                               "dependencies": {
                                 "inflight": {
@@ -7381,8 +8010,8 @@
                                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                                   "dev": true,
                                   "requires": {
-                                    "once": "1.4.0",
-                                    "wrappy": "1.0.2"
+                                    "once": "^1.3.0",
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -7405,7 +8034,7 @@
                                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                                   "dev": true,
                                   "requires": {
-                                    "wrappy": "1.0.2"
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -7434,7 +8063,7 @@
                       "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
                       "dev": true,
                       "requires": {
-                        "rsvp": "3.2.1"
+                        "rsvp": "~3.2.1"
                       },
                       "dependencies": {
                         "rsvp": {
@@ -7451,8 +8080,8 @@
                       "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                       "dev": true,
                       "requires": {
-                        "debug": "2.3.3",
-                        "heimdalljs": "0.2.3"
+                        "debug": "^2.2.0",
+                        "heimdalljs": "^0.2.0"
                       }
                     },
                     "md5-hex": {
@@ -7461,7 +8090,7 @@
                       "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
                       "dev": true,
                       "requires": {
-                        "md5-o-matic": "0.1.1"
+                        "md5-o-matic": "^0.1.1"
                       },
                       "dependencies": {
                         "md5-o-matic": {
@@ -7495,8 +8124,8 @@
                       "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
                       "dev": true,
                       "requires": {
-                        "ensure-posix-path": "1.0.2",
-                        "matcher-collection": "1.0.4"
+                        "ensure-posix-path": "^1.0.0",
+                        "matcher-collection": "^1.0.0"
                       },
                       "dependencies": {
                         "ensure-posix-path": {
@@ -7511,7 +8140,7 @@
                           "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                           "dev": true,
                           "requires": {
-                            "minimatch": "3.0.3"
+                            "minimatch": "^3.0.2"
                           }
                         }
                       }
@@ -7524,9 +8153,9 @@
                   "integrity": "sha1-Q/PSyN/LK/BxSBJSzZt2QzwI7ss=",
                   "dev": true,
                   "requires": {
-                    "array-to-error": "1.1.1",
-                    "clean-css": "3.4.21",
-                    "pinkie-promise": "2.0.1"
+                    "array-to-error": "^1.0.0",
+                    "clean-css": "^3.4.5",
+                    "pinkie-promise": "^2.0.0"
                   },
                   "dependencies": {
                     "array-to-error": {
@@ -7535,7 +8164,7 @@
                       "integrity": "sha1-1ogSkm0UCXogVXmmZ+6vGFakTAc=",
                       "dev": true,
                       "requires": {
-                        "array-to-sentence": "1.1.0"
+                        "array-to-sentence": "^1.1.0"
                       },
                       "dependencies": {
                         "array-to-sentence": {
@@ -7552,8 +8181,8 @@
                       "integrity": "sha1-IQHV29GdY9vBanXr1XDnwzlI9ls=",
                       "dev": true,
                       "requires": {
-                        "commander": "2.8.1",
-                        "source-map": "0.4.4"
+                        "commander": "2.8.x",
+                        "source-map": "0.4.x"
                       },
                       "dependencies": {
                         "commander": {
@@ -7562,7 +8191,7 @@
                           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
                           "dev": true,
                           "requires": {
-                            "graceful-readlink": "1.0.1"
+                            "graceful-readlink": ">= 1.0.0"
                           },
                           "dependencies": {
                             "graceful-readlink": {
@@ -7579,7 +8208,7 @@
                           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                           "dev": true,
                           "requires": {
-                            "amdefine": "1.0.1"
+                            "amdefine": ">=0.0.4"
                           },
                           "dependencies": {
                             "amdefine": {
@@ -7598,7 +8227,7 @@
                       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                       "dev": true,
                       "requires": {
-                        "pinkie": "2.0.4"
+                        "pinkie": "^2.0.0"
                       },
                       "dependencies": {
                         "pinkie": {
@@ -7617,11 +8246,11 @@
                   "integrity": "sha1-UKikTCp5DfrEQbXJTszVRiY1+vY=",
                   "dev": true,
                   "requires": {
-                    "chalk": "1.1.3",
-                    "get-stdin": "4.0.1",
-                    "minimist": "1.2.0",
-                    "sum-up": "1.0.3",
-                    "xtend": "4.0.1"
+                    "chalk": "^1.0.0",
+                    "get-stdin": "^4.0.1",
+                    "minimist": "^1.1.1",
+                    "sum-up": "^1.0.1",
+                    "xtend": "^4.0.0"
                   },
                   "dependencies": {
                     "get-stdin": {
@@ -7642,7 +8271,7 @@
                       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
                       "dev": true,
                       "requires": {
-                        "chalk": "1.1.3"
+                        "chalk": "^1.0.0"
                       }
                     },
                     "xtend": {
@@ -7659,7 +8288,7 @@
                   "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                   "dev": true,
                   "requires": {
-                    "jsonify": "0.0.0"
+                    "jsonify": "~0.0.0"
                   },
                   "dependencies": {
                     "jsonify": {
@@ -7684,7 +8313,7 @@
               "integrity": "sha1-FZDfz1uPKYO6U+OYRGtoJAtMxoo=",
               "dev": true,
               "requires": {
-                "node-modules-path": "1.0.1"
+                "node-modules-path": "^1.0.0"
               }
             }
           }
@@ -7701,21 +8330,21 @@
           "integrity": "sha1-XxNdI9g1YdyN+0pNmYQgtpt0Cs0=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "cli-table2": "0.2.0",
-            "core-object": "1.1.0",
-            "debug": "2.3.3",
-            "ember-cli-babel": "5.1.10",
-            "ember-cli-version-checker": "1.2.0",
-            "ember-try-config": "2.1.0",
-            "extend": "3.0.0",
-            "fs-extra": "0.26.7",
-            "promise-map-series": "0.2.3",
-            "resolve": "1.1.7",
-            "rimraf": "2.5.4",
-            "rsvp": "3.3.3",
-            "semver": "5.3.0",
-            "sync-exec": "0.6.2"
+            "chalk": "^1.0.0",
+            "cli-table2": "^0.2.0",
+            "core-object": "^1.1.0",
+            "debug": "^2.2.0",
+            "ember-cli-babel": "^5.1.3",
+            "ember-cli-version-checker": "^1.1.6",
+            "ember-try-config": "^2.0.1",
+            "extend": "^3.0.0",
+            "fs-extra": "^0.26.0",
+            "promise-map-series": "^0.2.1",
+            "resolve": "^1.1.6",
+            "rimraf": "^2.3.2",
+            "rsvp": "^3.0.17",
+            "semver": "^5.1.0",
+            "sync-exec": "^0.6.2"
           },
           "dependencies": {
             "cli-table2": {
@@ -7724,9 +8353,9 @@
               "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
               "dev": true,
               "requires": {
-                "colors": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-                "lodash": "3.10.1",
-                "string-width": "1.0.2"
+                "colors": "^1.1.2",
+                "lodash": "^3.10.1",
+                "string-width": "^1.0.1"
               },
               "dependencies": {
                 "lodash": {
@@ -7741,9 +8370,9 @@
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
                   },
                   "dependencies": {
                     "code-point-at": {
@@ -7758,7 +8387,7 @@
                       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                       "dev": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -7775,7 +8404,7 @@
                       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -7802,7 +8431,7 @@
               "integrity": "sha1-yqKGt30bSF310vYsZ6bxmqi1gsQ=",
               "dev": true,
               "requires": {
-                "semver": "5.3.0"
+                "semver": "^5.3.0"
               }
             },
             "ember-try-config": {
@@ -7811,10 +8440,10 @@
               "integrity": "sha1-4OFWIppUI0aljub2rWBRBMmO3+A=",
               "dev": true,
               "requires": {
-                "lodash": "4.17.2",
-                "node-fetch": "1.6.3",
-                "rsvp": "3.3.3",
-                "semver": "5.3.0"
+                "lodash": "^4.6.1",
+                "node-fetch": "^1.3.3",
+                "rsvp": "^3.2.1",
+                "semver": "^5.1.0"
               },
               "dependencies": {
                 "node-fetch": {
@@ -7823,8 +8452,8 @@
                   "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
                   "dev": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "is-stream": "1.1.0"
+                    "encoding": "^0.1.11",
+                    "is-stream": "^1.0.1"
                   },
                   "dependencies": {
                     "encoding": {
@@ -7833,7 +8462,7 @@
                       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                       "dev": true,
                       "requires": {
-                        "iconv-lite": "0.4.15"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -7866,11 +8495,11 @@
               "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "2.4.0",
-                "klaw": "1.3.1",
-                "path-is-absolute": "1.0.1",
-                "rimraf": "2.5.4"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
               },
               "dependencies": {
                 "graceful-fs": {
@@ -7885,7 +8514,7 @@
                   "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11"
+                    "graceful-fs": "^4.1.6"
                   }
                 },
                 "klaw": {
@@ -7894,7 +8523,7 @@
                   "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11"
+                    "graceful-fs": "^4.1.9"
                   }
                 },
                 "path-is-absolute": {
@@ -7911,7 +8540,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -7920,12 +8549,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -7940,8 +8569,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -7964,7 +8593,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -8011,32 +8640,32 @@
           "integrity": "sha1-we4/Qs3Ikfs9xlCoki1R7IR9DWY=",
           "dev": true,
           "requires": {
-            "accepts": "1.3.3",
+            "accepts": "~1.3.3",
             "array-flatten": "1.1.1",
             "content-disposition": "0.5.1",
-            "content-type": "1.0.2",
+            "content-type": "~1.0.2",
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
-            "debug": "2.2.0",
-            "depd": "1.1.0",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.7.0",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
             "finalhandler": "0.5.0",
             "fresh": "0.3.0",
             "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.1",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "1.1.2",
+            "proxy-addr": "~1.1.2",
             "qs": "6.2.0",
-            "range-parser": "1.2.0",
+            "range-parser": "~1.2.0",
             "send": "0.14.1",
-            "serve-static": "1.11.1",
-            "type-is": "1.6.14",
+            "serve-static": "~1.11.1",
+            "type-is": "~1.6.13",
             "utils-merge": "1.0.0",
-            "vary": "1.1.0"
+            "vary": "~1.1.0"
           },
           "dependencies": {
             "accepts": {
@@ -8045,7 +8674,7 @@
               "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
               "dev": true,
               "requires": {
-                "mime-types": "2.1.13",
+                "mime-types": "~2.1.11",
                 "negotiator": "0.6.1"
               },
               "dependencies": {
@@ -8055,7 +8684,7 @@
                   "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
                   "dev": true,
                   "requires": {
-                    "mime-db": "1.25.0"
+                    "mime-db": "~1.25.0"
                   },
                   "dependencies": {
                     "mime-db": {
@@ -8151,11 +8780,11 @@
               "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
               "dev": true,
               "requires": {
-                "debug": "2.2.0",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "statuses": "1.3.1",
-                "unpipe": "1.0.0"
+                "debug": "~2.2.0",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "statuses": "~1.3.0",
+                "unpipe": "~1.0.0"
               },
               "dependencies": {
                 "statuses": {
@@ -8225,7 +8854,7 @@
               "integrity": "sha1-tMxfImENlTWCTBI675089zxAujc=",
               "dev": true,
               "requires": {
-                "forwarded": "0.1.0",
+                "forwarded": "~0.1.0",
                 "ipaddr.js": "1.1.1"
               },
               "dependencies": {
@@ -8261,19 +8890,19 @@
               "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o=",
               "dev": true,
               "requires": {
-                "debug": "2.2.0",
-                "depd": "1.1.0",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "etag": "1.7.0",
+                "debug": "~2.2.0",
+                "depd": "~1.1.0",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "etag": "~1.7.0",
                 "fresh": "0.3.0",
-                "http-errors": "1.5.1",
+                "http-errors": "~1.5.0",
                 "mime": "1.3.4",
                 "ms": "0.7.1",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.3.1"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.3.0"
               },
               "dependencies": {
                 "destroy": {
@@ -8290,7 +8919,7 @@
                   "requires": {
                     "inherits": "2.0.3",
                     "setprototypeof": "1.0.2",
-                    "statuses": "1.3.1"
+                    "statuses": ">= 1.3.1 < 2"
                   },
                   "dependencies": {
                     "inherits": {
@@ -8333,9 +8962,9 @@
               "integrity": "sha1-1sznaTUF9zPHWd5Xvvwa92wPCAU=",
               "dev": true,
               "requires": {
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.1",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.1",
                 "send": "0.14.1"
               }
             },
@@ -8346,7 +8975,7 @@
               "dev": true,
               "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.13"
+                "mime-types": "~2.1.13"
               },
               "dependencies": {
                 "media-typer": {
@@ -8361,7 +8990,7 @@
                   "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
                   "dev": true,
                   "requires": {
-                    "mime-db": "1.25.0"
+                    "mime-db": "~1.25.0"
                   },
                   "dependencies": {
                     "mime-db": {
@@ -8400,8 +9029,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -8410,7 +9039,7 @@
               "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
               "dev": true,
               "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
               }
             },
             "pinkie-promise": {
@@ -8419,7 +9048,7 @@
               "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
               "dev": true,
               "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
               },
               "dependencies": {
                 "pinkie": {
@@ -8438,11 +9067,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.5.4"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           },
           "dependencies": {
             "graceful-fs": {
@@ -8457,7 +9086,7 @@
               "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
               }
             },
             "klaw": {
@@ -8466,7 +9095,7 @@
               "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.9"
               }
             },
             "path-is-absolute": {
@@ -8481,7 +9110,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -8490,12 +9119,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -8510,8 +9139,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -8534,7 +9163,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -8563,8 +9192,8 @@
           "integrity": "sha1-9rddcNsiwfOwXVkicPTtbJwvgt0=",
           "dev": true,
           "requires": {
-            "debug": "2.3.3",
-            "fast-ordered-set": "1.0.3"
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.2"
           },
           "dependencies": {
             "fast-ordered-set": {
@@ -8573,7 +9202,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               },
               "dependencies": {
                 "blank-object": {
@@ -8604,11 +9233,11 @@
           "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.3",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           },
           "dependencies": {
             "inflight": {
@@ -8617,8 +9246,8 @@
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               },
               "dependencies": {
                 "wrappy": {
@@ -8641,7 +9270,7 @@
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               },
               "dependencies": {
                 "wrappy": {
@@ -8666,8 +9295,8 @@
           "integrity": "sha1-c0sy3myg425RtZweARX/hg12aP0=",
           "dev": true,
           "requires": {
-            "eventemitter3": "1.2.0",
-            "requires-port": "1.0.0"
+            "eventemitter3": "1.x.x",
+            "requires-port": "1.x.x"
           },
           "dependencies": {
             "eventemitter3": {
@@ -8696,19 +9325,19 @@
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "1.4.0",
-            "ansi-regex": "2.0.0",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.1.0",
-            "figures": "1.7.0",
-            "lodash": "4.17.2",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
+            "ansi-escapes": "^1.1.0",
+            "ansi-regex": "^2.0.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "readline2": "^1.0.1",
+            "run-async": "^0.1.0",
+            "rx-lite": "^3.1.2",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
           },
           "dependencies": {
             "ansi-escapes": {
@@ -8729,7 +9358,7 @@
               "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
               "dev": true,
               "requires": {
-                "restore-cursor": "1.0.1"
+                "restore-cursor": "^1.0.1"
               },
               "dependencies": {
                 "restore-cursor": {
@@ -8738,8 +9367,8 @@
                   "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
                   "dev": true,
                   "requires": {
-                    "exit-hook": "1.1.1",
-                    "onetime": "1.1.0"
+                    "exit-hook": "^1.0.0",
+                    "onetime": "^1.0.0"
                   },
                   "dependencies": {
                     "exit-hook": {
@@ -8770,8 +9399,8 @@
               "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
               "dev": true,
               "requires": {
-                "escape-string-regexp": "1.0.5",
-                "object-assign": "4.1.0"
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
               },
               "dependencies": {
                 "object-assign": {
@@ -8788,8 +9417,8 @@
               "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
                 "mute-stream": "0.0.5"
               },
               "dependencies": {
@@ -8805,7 +9434,7 @@
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "1.0.1"
+                    "number-is-nan": "^1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -8830,7 +9459,7 @@
               "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
               "dev": true,
               "requires": {
-                "once": "1.4.0"
+                "once": "^1.3.0"
               },
               "dependencies": {
                 "once": {
@@ -8839,7 +9468,7 @@
                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
                   "requires": {
-                    "wrappy": "1.0.2"
+                    "wrappy": "1"
                   },
                   "dependencies": {
                     "wrappy": {
@@ -8864,9 +9493,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               },
               "dependencies": {
                 "code-point-at": {
@@ -8881,7 +9510,7 @@
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "1.0.1"
+                    "number-is-nan": "^1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -8900,7 +9529,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               }
             }
           }
@@ -8923,10 +9552,10 @@
           "integrity": "sha1-CYBL9w+K77unRfXVbSpN6/InEf8=",
           "dev": true,
           "requires": {
-            "debug": "2.3.3",
-            "lodash.assign": "3.2.0",
-            "request": "2.79.0",
-            "rsvp": "3.3.3"
+            "debug": "^2.1.0",
+            "lodash.assign": "^3.2.0",
+            "request": "^2.27.0",
+            "rsvp": "^3.0.21"
           },
           "dependencies": {
             "lodash.assign": {
@@ -8935,9 +9564,9 @@
               "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
               "dev": true,
               "requires": {
-                "lodash._baseassign": "3.2.0",
-                "lodash._createassigner": "3.1.1",
-                "lodash.keys": "3.1.2"
+                "lodash._baseassign": "^3.0.0",
+                "lodash._createassigner": "^3.0.0",
+                "lodash.keys": "^3.0.0"
               },
               "dependencies": {
                 "lodash._baseassign": {
@@ -8946,8 +9575,8 @@
                   "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
                   "dev": true,
                   "requires": {
-                    "lodash._basecopy": "3.0.1",
-                    "lodash.keys": "3.1.2"
+                    "lodash._basecopy": "^3.0.0",
+                    "lodash.keys": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._basecopy": {
@@ -8964,9 +9593,9 @@
                   "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
                   "dev": true,
                   "requires": {
-                    "lodash._bindcallback": "3.0.1",
-                    "lodash._isiterateecall": "3.0.9",
-                    "lodash.restparam": "3.6.1"
+                    "lodash._bindcallback": "^3.0.0",
+                    "lodash._isiterateecall": "^3.0.0",
+                    "lodash.restparam": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._bindcallback": {
@@ -8995,9 +9624,9 @@
                   "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
                   "dev": true,
                   "requires": {
-                    "lodash._getnative": "3.9.1",
-                    "lodash.isarguments": "3.1.0",
-                    "lodash.isarray": "3.0.4"
+                    "lodash._getnative": "^3.0.0",
+                    "lodash.isarguments": "^3.0.0",
+                    "lodash.isarray": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._getnative": {
@@ -9028,26 +9657,26 @@
               "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
               "dev": true,
               "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.5.0",
-                "caseless": "0.11.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.0",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.2",
-                "har-validator": "2.0.6",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.13",
-                "oauth-sign": "0.8.2",
-                "qs": "6.3.0",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.4.3",
-                "uuid": "3.0.1"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.11.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~2.0.6",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "qs": "~6.3.0",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "~0.4.1",
+                "uuid": "^3.0.0"
               },
               "dependencies": {
                 "aws-sign2": {
@@ -9074,7 +9703,7 @@
                   "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
                   "requires": {
-                    "delayed-stream": "1.0.0"
+                    "delayed-stream": "~1.0.0"
                   },
                   "dependencies": {
                     "delayed-stream": {
@@ -9103,9 +9732,9 @@
                   "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
                   "dev": true,
                   "requires": {
-                    "asynckit": "0.4.0",
-                    "combined-stream": "1.0.5",
-                    "mime-types": "2.1.13"
+                    "asynckit": "^0.4.0",
+                    "combined-stream": "^1.0.5",
+                    "mime-types": "^2.1.12"
                   },
                   "dependencies": {
                     "asynckit": {
@@ -9122,10 +9751,10 @@
                   "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
                   "dev": true,
                   "requires": {
-                    "chalk": "1.1.3",
-                    "commander": "2.9.0",
-                    "is-my-json-valid": "2.15.0",
-                    "pinkie-promise": "2.0.1"
+                    "chalk": "^1.1.1",
+                    "commander": "^2.9.0",
+                    "is-my-json-valid": "^2.12.4",
+                    "pinkie-promise": "^2.0.0"
                   },
                   "dependencies": {
                     "commander": {
@@ -9134,7 +9763,7 @@
                       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                       "dev": true,
                       "requires": {
-                        "graceful-readlink": "1.0.1"
+                        "graceful-readlink": ">= 1.0.0"
                       },
                       "dependencies": {
                         "graceful-readlink": {
@@ -9151,10 +9780,10 @@
                       "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
                       "dev": true,
                       "requires": {
-                        "generate-function": "2.0.0",
-                        "generate-object-property": "1.2.0",
-                        "jsonpointer": "4.0.0",
-                        "xtend": "4.0.1"
+                        "generate-function": "^2.0.0",
+                        "generate-object-property": "^1.1.0",
+                        "jsonpointer": "^4.0.0",
+                        "xtend": "^4.0.0"
                       },
                       "dependencies": {
                         "generate-function": {
@@ -9169,7 +9798,7 @@
                           "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                           "dev": true,
                           "requires": {
-                            "is-property": "1.0.2"
+                            "is-property": "^1.0.0"
                           },
                           "dependencies": {
                             "is-property": {
@@ -9200,7 +9829,7 @@
                       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                       "dev": true,
                       "requires": {
-                        "pinkie": "2.0.4"
+                        "pinkie": "^2.0.0"
                       },
                       "dependencies": {
                         "pinkie": {
@@ -9219,10 +9848,10 @@
                   "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                   "dev": true,
                   "requires": {
-                    "boom": "2.10.1",
-                    "cryptiles": "2.0.5",
-                    "hoek": "2.16.3",
-                    "sntp": "1.0.9"
+                    "boom": "2.x.x",
+                    "cryptiles": "2.x.x",
+                    "hoek": "2.x.x",
+                    "sntp": "1.x.x"
                   },
                   "dependencies": {
                     "boom": {
@@ -9231,7 +9860,7 @@
                       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                       "dev": true,
                       "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                       }
                     },
                     "cryptiles": {
@@ -9240,7 +9869,7 @@
                       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                       "dev": true,
                       "requires": {
-                        "boom": "2.10.1"
+                        "boom": "2.x.x"
                       }
                     },
                     "hoek": {
@@ -9255,7 +9884,7 @@
                       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                       "dev": true,
                       "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                       }
                     }
                   }
@@ -9266,9 +9895,9 @@
                   "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                   "dev": true,
                   "requires": {
-                    "assert-plus": "0.2.0",
-                    "jsprim": "1.3.1",
-                    "sshpk": "1.10.1"
+                    "assert-plus": "^0.2.0",
+                    "jsprim": "^1.2.2",
+                    "sshpk": "^1.7.0"
                   },
                   "dependencies": {
                     "assert-plus": {
@@ -9317,15 +9946,15 @@
                       "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
                       "dev": true,
                       "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                        "getpass": "0.1.6",
-                        "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jodid25519": "^1.0.0",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.14.0"
                       },
                       "dependencies": {
                         "asn1": {
@@ -9346,7 +9975,7 @@
                           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                           "dev": true,
                           "requires": {
-                            "assert-plus": "1.0.0"
+                            "assert-plus": "^1.0.0"
                           }
                         },
                         "getpass": {
@@ -9355,7 +9984,7 @@
                           "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
                           "dev": true,
                           "requires": {
-                            "assert-plus": "1.0.0"
+                            "assert-plus": "^1.0.0"
                           }
                         }
                       }
@@ -9386,7 +10015,7 @@
                   "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
                   "dev": true,
                   "requires": {
-                    "mime-db": "1.25.0"
+                    "mime-db": "~1.25.0"
                   },
                   "dependencies": {
                     "mime-db": {
@@ -9421,7 +10050,7 @@
                   "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                   "dev": true,
                   "requires": {
-                    "punycode": "1.4.1"
+                    "punycode": "^1.4.1"
                   },
                   "dependencies": {
                     "punycode": {
@@ -9460,11 +10089,11 @@
           "integrity": "sha1-h2Zddn111qslQR1wXd12xxKF2rc=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "entities": "1.1.1",
-            "linkify-it": "1.2.4",
-            "mdurl": "1.0.1",
-            "uc.micro": "1.0.3"
+            "argparse": "^1.0.7",
+            "entities": "~1.1.1",
+            "linkify-it": "~1.2.2",
+            "mdurl": "~1.0.1",
+            "uc.micro": "^1.0.1"
           },
           "dependencies": {
             "argparse": {
@@ -9473,7 +10102,7 @@
               "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
               "dev": true,
               "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
               },
               "dependencies": {
                 "sprintf-js": {
@@ -9496,7 +10125,7 @@
               "integrity": "sha1-B3NSbDF8j9E71TTuHRgP+Iq/iBo=",
               "dev": true,
               "requires": {
-                "uc.micro": "1.0.3"
+                "uc.micro": "^1.0.1"
               }
             },
             "mdurl": {
@@ -9519,11 +10148,11 @@
           "integrity": "sha1-x3qFM8IXC0bSqQejw0UtTX9Kpds=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "cardinal": "0.5.0",
-            "cli-table": "0.3.1",
-            "lodash.merge": "3.3.2",
-            "markdown-it": "4.4.0"
+            "ansi-styles": "^2.1.0",
+            "cardinal": "^0.5.0",
+            "cli-table": "^0.3.1",
+            "lodash.merge": "^3.3.2",
+            "markdown-it": "^4.4.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -9538,8 +10167,8 @@
               "integrity": "sha1-ANX2YdvUqr/ffUHOSKWlm8o1opE=",
               "dev": true,
               "requires": {
-                "ansicolors": "0.2.1",
-                "redeyed": "0.5.0"
+                "ansicolors": "~0.2.1",
+                "redeyed": "~0.5.0"
               },
               "dependencies": {
                 "ansicolors": {
@@ -9554,7 +10183,7 @@
                   "integrity": "sha1-erAA5g7jh1rBFdKe2zLBQDxsJdE=",
                   "dev": true,
                   "requires": {
-                    "esprima-fb": "12001.1.0-dev-harmony-fb"
+                    "esprima-fb": "~12001.1.0-dev-harmony-fb"
                   },
                   "dependencies": {
                     "esprima-fb": {
@@ -9590,17 +10219,17 @@
               "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
               "dev": true,
               "requires": {
-                "lodash._arraycopy": "3.0.0",
-                "lodash._arrayeach": "3.0.0",
-                "lodash._createassigner": "3.1.1",
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4",
-                "lodash.isplainobject": "3.2.0",
-                "lodash.istypedarray": "3.0.6",
-                "lodash.keys": "3.1.2",
-                "lodash.keysin": "3.0.8",
-                "lodash.toplainobject": "3.0.0"
+                "lodash._arraycopy": "^3.0.0",
+                "lodash._arrayeach": "^3.0.0",
+                "lodash._createassigner": "^3.0.0",
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.isplainobject": "^3.0.0",
+                "lodash.istypedarray": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.keysin": "^3.0.0",
+                "lodash.toplainobject": "^3.0.0"
               },
               "dependencies": {
                 "lodash._arraycopy": {
@@ -9621,9 +10250,9 @@
                   "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
                   "dev": true,
                   "requires": {
-                    "lodash._bindcallback": "3.0.1",
-                    "lodash._isiterateecall": "3.0.9",
-                    "lodash.restparam": "3.6.1"
+                    "lodash._bindcallback": "^3.0.0",
+                    "lodash._isiterateecall": "^3.0.0",
+                    "lodash.restparam": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._bindcallback": {
@@ -9670,9 +10299,9 @@
                   "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
                   "dev": true,
                   "requires": {
-                    "lodash._basefor": "3.0.3",
-                    "lodash.isarguments": "3.1.0",
-                    "lodash.keysin": "3.0.8"
+                    "lodash._basefor": "^3.0.0",
+                    "lodash.isarguments": "^3.0.0",
+                    "lodash.keysin": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._basefor": {
@@ -9695,9 +10324,9 @@
                   "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
                   "dev": true,
                   "requires": {
-                    "lodash._getnative": "3.9.1",
-                    "lodash.isarguments": "3.1.0",
-                    "lodash.isarray": "3.0.4"
+                    "lodash._getnative": "^3.0.0",
+                    "lodash.isarguments": "^3.0.0",
+                    "lodash.isarray": "^3.0.0"
                   }
                 },
                 "lodash.keysin": {
@@ -9706,8 +10335,8 @@
                   "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
                   "dev": true,
                   "requires": {
-                    "lodash.isarguments": "3.1.0",
-                    "lodash.isarray": "3.0.4"
+                    "lodash.isarguments": "^3.0.0",
+                    "lodash.isarray": "^3.0.0"
                   }
                 },
                 "lodash.toplainobject": {
@@ -9716,8 +10345,8 @@
                   "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
                   "dev": true,
                   "requires": {
-                    "lodash._basecopy": "3.0.1",
-                    "lodash.keysin": "3.0.8"
+                    "lodash._basecopy": "^3.0.0",
+                    "lodash.keysin": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._basecopy": {
@@ -9736,11 +10365,11 @@
               "integrity": "sha1-PfNz2+pYepp/7z5WMRtokI91xBQ=",
               "dev": true,
               "requires": {
-                "argparse": "1.0.9",
-                "entities": "1.1.1",
-                "linkify-it": "1.2.4",
-                "mdurl": "1.0.1",
-                "uc.micro": "1.0.3"
+                "argparse": "~1.0.2",
+                "entities": "~1.1.1",
+                "linkify-it": "~1.2.0",
+                "mdurl": "~1.0.0",
+                "uc.micro": "^1.0.0"
               },
               "dependencies": {
                 "argparse": {
@@ -9749,7 +10378,7 @@
                   "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
                   "dev": true,
                   "requires": {
-                    "sprintf-js": "1.0.3"
+                    "sprintf-js": "~1.0.2"
                   },
                   "dependencies": {
                     "sprintf-js": {
@@ -9772,7 +10401,7 @@
                   "integrity": "sha1-B3NSbDF8j9E71TTuHRgP+Iq/iBo=",
                   "dev": true,
                   "requires": {
-                    "uc.micro": "1.0.3"
+                    "uc.micro": "^1.0.1"
                   }
                 },
                 "mdurl": {
@@ -9797,7 +10426,7 @@
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.6"
+            "brace-expansion": "^1.0.0"
           },
           "dependencies": {
             "brace-expansion": {
@@ -9806,7 +10435,7 @@
               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
               "dev": true,
               "requires": {
-                "balanced-match": "0.4.2",
+                "balanced-match": "^0.4.1",
                 "concat-map": "0.0.1"
               },
               "dependencies": {
@@ -9832,11 +10461,11 @@
           "integrity": "sha1-6xDKjlDRq+D409rVwCAdBS2YHGI=",
           "dev": true,
           "requires": {
-            "basic-auth": "1.0.4",
-            "debug": "2.2.0",
-            "depd": "1.1.0",
-            "on-finished": "2.3.0",
-            "on-headers": "1.0.1"
+            "basic-auth": "~1.0.3",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "on-finished": "~2.3.0",
+            "on-headers": "~1.0.1"
           },
           "dependencies": {
             "basic-auth": {
@@ -9911,7 +10540,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "1"
           },
           "dependencies": {
             "abbrev": {
@@ -9928,77 +10557,77 @@
           "integrity": "sha1-X81xmZw9VLqg4cJ6xE+EobgrRVk=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.7",
-            "ansi": "0.3.1",
-            "ansi-regex": "2.0.0",
-            "ansicolors": "0.3.2",
-            "ansistyles": "0.1.3",
-            "archy": "1.0.0",
-            "async-some": "1.0.2",
+            "abbrev": "~1.0.7",
+            "ansi": "~0.3.1",
+            "ansi-regex": "*",
+            "ansicolors": "~0.3.2",
+            "ansistyles": "~0.1.3",
+            "archy": "~1.0.0",
+            "async-some": "~1.0.2",
             "block-stream": "0.0.9",
-            "char-spinner": "1.0.1",
-            "chmodr": "1.0.2",
-            "chownr": "1.0.1",
-            "cmd-shim": "2.0.2",
-            "columnify": "1.5.4",
-            "config-chain": "1.1.10",
-            "dezalgo": "1.0.3",
-            "editor": "1.0.0",
-            "fs-vacuum": "1.2.9",
-            "fs-write-stream-atomic": "1.0.8",
-            "fstream": "1.0.11",
-            "fstream-npm": "1.0.7",
-            "github-url-from-git": "1.4.0",
-            "github-url-from-username-repo": "1.0.2",
-            "glob": "7.0.3",
-            "graceful-fs": "4.1.4",
-            "hosted-git-info": "2.1.4",
-            "imurmurhash": "0.1.4",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "ini": "1.3.4",
-            "init-package-json": "1.9.3",
-            "lockfile": "1.0.1",
-            "lru-cache": "4.0.1",
-            "minimatch": "3.0.0",
-            "mkdirp": "0.5.1",
-            "node-gyp": "3.3.1",
-            "nopt": "3.0.6",
-            "normalize-git-url": "3.0.2",
-            "normalize-package-data": "2.3.5",
-            "npm-cache-filename": "1.0.2",
-            "npm-install-checks": "1.0.7",
-            "npm-package-arg": "4.1.0",
-            "npm-registry-client": "7.1.0",
-            "npm-user-validate": "0.1.2",
-            "npmlog": "2.0.3",
-            "once": "1.3.3",
-            "opener": "1.4.1",
-            "osenv": "0.1.3",
-            "path-is-inside": "1.0.2",
-            "read": "1.0.7",
-            "read-installed": "4.0.3",
-            "read-package-json": "2.0.4",
-            "readable-stream": "2.1.2",
-            "realize-package-specifier": "3.0.3",
-            "request": "2.72.0",
-            "retry": "0.9.0",
-            "rimraf": "2.5.2",
-            "semver": "5.1.0",
-            "sha": "2.0.1",
-            "slide": "1.1.6",
-            "sorted-object": "2.0.0",
-            "spdx-license-ids": "1.2.1",
-            "strip-ansi": "3.0.1",
-            "tar": "2.2.1",
-            "text-table": "0.2.0",
+            "char-spinner": "~1.0.1",
+            "chmodr": "~1.0.2",
+            "chownr": "~1.0.1",
+            "cmd-shim": "~2.0.2",
+            "columnify": "~1.5.4",
+            "config-chain": "~1.1.10",
+            "dezalgo": "~1.0.3",
+            "editor": "~1.0.0",
+            "fs-vacuum": "~1.2.9",
+            "fs-write-stream-atomic": "~1.0.8",
+            "fstream": "~1.0.8",
+            "fstream-npm": "~1.0.7",
+            "github-url-from-git": "~1.4.0",
+            "github-url-from-username-repo": "~1.0.2",
+            "glob": "~7.0.3",
+            "graceful-fs": "~4.1.4",
+            "hosted-git-info": "~2.1.4",
+            "imurmurhash": "*",
+            "inflight": "~1.0.4",
+            "inherits": "~2.0.1",
+            "ini": "~1.3.4",
+            "init-package-json": "~1.9.3",
+            "lockfile": "~1.0.1",
+            "lru-cache": "~4.0.1",
+            "minimatch": "~3.0.0",
+            "mkdirp": "~0.5.1",
+            "node-gyp": "~3.3.1",
+            "nopt": "~3.0.6",
+            "normalize-git-url": "~3.0.2",
+            "normalize-package-data": "~2.3.5",
+            "npm-cache-filename": "~1.0.2",
+            "npm-install-checks": "~1.0.7",
+            "npm-package-arg": "~4.1.0",
+            "npm-registry-client": "~7.1.0",
+            "npm-user-validate": "~0.1.2",
+            "npmlog": "~2.0.3",
+            "once": "~1.3.3",
+            "opener": "~1.4.1",
+            "osenv": "~0.1.3",
+            "path-is-inside": "~1.0.0",
+            "read": "~1.0.7",
+            "read-installed": "~4.0.3",
+            "read-package-json": "~2.0.4",
+            "readable-stream": "~2.1.2",
+            "realize-package-specifier": "~3.0.3",
+            "request": "~2.72.0",
+            "retry": "~0.9.0",
+            "rimraf": "~2.5.2",
+            "semver": "~5.1.0",
+            "sha": "~2.0.1",
+            "slide": "~1.1.6",
+            "sorted-object": "~2.0.0",
+            "spdx-license-ids": "~1.2.1",
+            "strip-ansi": "~3.0.1",
+            "tar": "~2.2.1",
+            "text-table": "~0.2.0",
             "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "validate-npm-package-license": "3.0.1",
-            "validate-npm-package-name": "2.2.2",
-            "which": "1.2.8",
-            "wrappy": "1.0.1",
-            "write-file-atomic": "1.1.4"
+            "umask": "~1.1.0",
+            "validate-npm-package-license": "~3.0.1",
+            "validate-npm-package-name": "~2.2.2",
+            "which": "~1.2.8",
+            "wrappy": "~1.0.1",
+            "write-file-atomic": "~1.1.4"
           },
           "dependencies": {
             "abbrev": {
@@ -10031,7 +10660,7 @@
               "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.1"
+                "inherits": "~2.0.0"
               }
             },
             "char-spinner": {
@@ -10058,8 +10687,8 @@
               "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.4",
-                "mkdirp": "0.5.1"
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "~0.5.0"
               }
             },
             "columnify": {
@@ -10068,8 +10697,8 @@
               "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
               "dev": true,
               "requires": {
-                "strip-ansi": "3.0.1",
-                "wcwidth": "1.0.0"
+                "strip-ansi": "^3.0.0",
+                "wcwidth": "^1.0.0"
               },
               "dependencies": {
                 "wcwidth": {
@@ -10078,7 +10707,7 @@
                   "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
                   "dev": true,
                   "requires": {
-                    "defaults": "1.0.3"
+                    "defaults": "^1.0.0"
                   },
                   "dependencies": {
                     "defaults": {
@@ -10087,7 +10716,7 @@
                       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                       "dev": true,
                       "requires": {
-                        "clone": "1.0.2"
+                        "clone": "^1.0.2"
                       },
                       "dependencies": {
                         "clone": {
@@ -10108,8 +10737,8 @@
               "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
               "dev": true,
               "requires": {
-                "ini": "1.3.4",
-                "proto-list": "1.2.4"
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
               },
               "dependencies": {
                 "proto-list": {
@@ -10132,9 +10761,9 @@
               "integrity": "sha1-T5AZOrjqAokJlbzU6ARlml02ay0=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.4",
-                "path-is-inside": "1.0.2",
-                "rimraf": "2.5.2"
+                "graceful-fs": "^4.1.2",
+                "path-is-inside": "^1.0.1",
+                "rimraf": "^2.5.2"
               }
             },
             "fs-write-stream-atomic": {
@@ -10143,10 +10772,10 @@
               "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.4",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "readable-stream": "2.1.2"
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
               },
               "dependencies": {
                 "iferr": {
@@ -10169,11 +10798,11 @@
               "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
               "dev": true,
               "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.0",
-                "once": "1.3.3",
-                "path-is-absolute": "1.0.0"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               },
               "dependencies": {
                 "path-is-absolute": {
@@ -10220,14 +10849,14 @@
               "integrity": "sha1-yi/5Rwm22aqtZlM8EaCv9kXxXH0=",
               "dev": true,
               "requires": {
-                "glob": "6.0.4",
-                "npm-package-arg": "4.1.0",
-                "promzard": "0.3.0",
-                "read": "1.0.7",
-                "read-package-json": "2.0.4",
-                "semver": "5.1.0",
-                "validate-npm-package-license": "3.0.1",
-                "validate-npm-package-name": "2.2.2"
+                "glob": "^6.0.0",
+                "npm-package-arg": "^4.0.0",
+                "promzard": "^0.3.0",
+                "read": "~1.0.1",
+                "read-package-json": "1 || 2",
+                "semver": "2.x || 3.x || 4 || 5",
+                "validate-npm-package-license": "^3.0.1",
+                "validate-npm-package-name": "^2.0.1"
               },
               "dependencies": {
                 "glob": {
@@ -10236,11 +10865,11 @@
                   "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.1",
-                    "minimatch": "3.0.0",
-                    "once": "1.3.3",
-                    "path-is-absolute": "1.0.0"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "path-is-absolute": {
@@ -10257,7 +10886,7 @@
                   "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
                   "dev": true,
                   "requires": {
-                    "read": "1.0.7"
+                    "read": "1"
                   }
                 }
               }
@@ -10274,8 +10903,8 @@
               "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
               "dev": true,
               "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.0.0"
+                "pseudomap": "^1.0.1",
+                "yallist": "^2.0.0"
               },
               "dependencies": {
                 "pseudomap": {
@@ -10298,7 +10927,7 @@
               "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.1"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -10307,7 +10936,7 @@
                   "integrity": "sha1-2l+3iu9MRMnkrPUlBk+zII66sEU=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.2.1",
+                    "balanced-match": "^0.2.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -10350,20 +10979,20 @@
               "integrity": "sha1-gPe218L5wElbpCxRimcMmb325KA=",
               "dev": true,
               "requires": {
-                "fstream": "1.0.11",
-                "glob": "4.5.3",
-                "graceful-fs": "4.1.4",
-                "minimatch": "1.0.0",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "npmlog": "2.0.3",
-                "osenv": "0.1.3",
-                "path-array": "1.0.1",
-                "request": "2.72.0",
-                "rimraf": "2.5.2",
-                "semver": "5.1.0",
-                "tar": "2.2.1",
-                "which": "1.2.8"
+                "fstream": "^1.0.0",
+                "glob": "3 || 4",
+                "graceful-fs": "^4.1.2",
+                "minimatch": "1",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2",
+                "osenv": "0",
+                "path-array": "^1.0.0",
+                "request": "2",
+                "rimraf": "2",
+                "semver": "2.x || 3.x || 4 || 5",
+                "tar": "^2.0.0",
+                "which": "1"
               },
               "dependencies": {
                 "glob": {
@@ -10372,10 +11001,10 @@
                   "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.1",
-                    "minimatch": "2.0.10",
-                    "once": "1.3.3"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^2.0.1",
+                    "once": "^1.3.0"
                   },
                   "dependencies": {
                     "minimatch": {
@@ -10384,7 +11013,7 @@
                       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.3"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -10393,7 +11022,7 @@
                           "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.3.0",
+                            "balanced-match": "^0.3.0",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -10421,8 +11050,8 @@
                   "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
                   "dev": true,
                   "requires": {
-                    "lru-cache": "2.7.3",
-                    "sigmund": "1.0.1"
+                    "lru-cache": "2",
+                    "sigmund": "~1.0.0"
                   },
                   "dependencies": {
                     "lru-cache": {
@@ -10445,7 +11074,7 @@
                   "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
                   "dev": true,
                   "requires": {
-                    "array-index": "1.0.0"
+                    "array-index": "^1.0.0"
                   },
                   "dependencies": {
                     "array-index": {
@@ -10454,8 +11083,8 @@
                       "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
                       "dev": true,
                       "requires": {
-                        "debug": "2.2.0",
-                        "es6-symbol": "3.0.2"
+                        "debug": "^2.2.0",
+                        "es6-symbol": "^3.0.2"
                       },
                       "dependencies": {
                         "debug": {
@@ -10481,8 +11110,8 @@
                           "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk=",
                           "dev": true,
                           "requires": {
-                            "d": "0.1.1",
-                            "es5-ext": "0.10.11"
+                            "d": "~0.1.1",
+                            "es5-ext": "~0.10.10"
                           },
                           "dependencies": {
                             "d": {
@@ -10491,7 +11120,7 @@
                               "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
                               "dev": true,
                               "requires": {
-                                "es5-ext": "0.10.11"
+                                "es5-ext": "~0.10.2"
                               }
                             },
                             "es5-ext": {
@@ -10500,8 +11129,8 @@
                               "integrity": "sha1-gYTD5wWoIJSMLb4EOEk3mx29DEU=",
                               "dev": true,
                               "requires": {
-                                "es6-iterator": "2.0.0",
-                                "es6-symbol": "3.0.2"
+                                "es6-iterator": "2",
+                                "es6-symbol": "~3.0.2"
                               },
                               "dependencies": {
                                 "es6-iterator": {
@@ -10510,9 +11139,9 @@
                                   "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
                                   "dev": true,
                                   "requires": {
-                                    "d": "0.1.1",
-                                    "es5-ext": "0.10.11",
-                                    "es6-symbol": "3.0.2"
+                                    "d": "^0.1.1",
+                                    "es5-ext": "^0.10.7",
+                                    "es6-symbol": "3"
                                   }
                                 }
                               }
@@ -10537,10 +11166,10 @@
               "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
               "dev": true,
               "requires": {
-                "hosted-git-info": "2.1.4",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.1.0",
-                "validate-npm-package-license": "3.0.1"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
               },
               "dependencies": {
                 "is-builtin-module": {
@@ -10549,7 +11178,7 @@
                   "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                   "dev": true,
                   "requires": {
-                    "builtin-modules": "1.1.0"
+                    "builtin-modules": "^1.0.0"
                   },
                   "dependencies": {
                     "builtin-modules": {
@@ -10574,8 +11203,8 @@
               "integrity": "sha1-bZGu2grJaAHx7Xqt7hFqbAoIalc=",
               "dev": true,
               "requires": {
-                "npmlog": "2.0.3",
-                "semver": "5.1.0"
+                "npmlog": "0.1 || 1 || 2",
+                "semver": "^2.3.0 || 3.x || 4 || 5"
               }
             },
             "npm-package-arg": {
@@ -10584,8 +11213,8 @@
               "integrity": "sha1-LgFfisAHN8uX+ZfJy/BZ9Cp0Un0=",
               "dev": true,
               "requires": {
-                "hosted-git-info": "2.1.4",
-                "semver": "5.1.0"
+                "hosted-git-info": "^2.1.4",
+                "semver": "4 || 5"
               }
             },
             "npm-registry-client": {
@@ -10594,19 +11223,19 @@
               "integrity": "sha1-474Uqyef5RI+FatcimUERUFWZKU=",
               "dev": true,
               "requires": {
-                "chownr": "1.0.1",
-                "concat-stream": "1.5.1",
-                "graceful-fs": "4.1.4",
-                "mkdirp": "0.5.1",
-                "normalize-package-data": "2.3.5",
-                "npm-package-arg": "4.1.0",
-                "npmlog": "2.0.3",
-                "once": "1.3.3",
-                "request": "2.72.0",
-                "retry": "0.8.0",
-                "rimraf": "2.5.2",
-                "semver": "5.1.0",
-                "slide": "1.1.6"
+                "chownr": "^1.0.1",
+                "concat-stream": "^1.4.6",
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "normalize-package-data": "~1.0.1 || ^2.0.0",
+                "npm-package-arg": "^3.0.0 || ^4.0.0",
+                "npmlog": "~2.0.0",
+                "once": "^1.3.0",
+                "request": "^2.47.0",
+                "retry": "^0.8.0",
+                "rimraf": "2",
+                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+                "slide": "^1.1.3"
               },
               "dependencies": {
                 "concat-stream": {
@@ -10615,9 +11244,9 @@
                   "integrity": "sha1-87gKz54fSOOHXAaItBtsMWAu6hw=",
                   "dev": true,
                   "requires": {
-                    "inherits": "2.0.1",
-                    "readable-stream": "2.0.5",
-                    "typedarray": "0.0.6"
+                    "inherits": "~2.0.1",
+                    "readable-stream": "~2.0.0",
+                    "typedarray": "~0.0.5"
                   },
                   "dependencies": {
                     "readable-stream": {
@@ -10626,12 +11255,12 @@
                       "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
                       "dev": true,
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.1",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "process-nextick-args": "1.0.6",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -10694,9 +11323,9 @@
               "integrity": "sha1-Ag+ZNR8MAuOZxnS6JW58TTs90pg=",
               "dev": true,
               "requires": {
-                "ansi": "0.3.1",
-                "are-we-there-yet": "1.1.2",
-                "gauge": "1.2.7"
+                "ansi": "~0.3.1",
+                "are-we-there-yet": "~1.1.2",
+                "gauge": "~1.2.5"
               },
               "dependencies": {
                 "are-we-there-yet": {
@@ -10705,8 +11334,8 @@
                   "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
                   "dev": true,
                   "requires": {
-                    "delegates": "1.0.0",
-                    "readable-stream": "2.1.2"
+                    "delegates": "^1.0.0",
+                    "readable-stream": "^2.0.0 || ^1.1.13"
                   },
                   "dependencies": {
                     "delegates": {
@@ -10723,11 +11352,11 @@
                   "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
                   "dev": true,
                   "requires": {
-                    "ansi": "0.3.1",
-                    "has-unicode": "2.0.0",
-                    "lodash.pad": "4.1.0",
-                    "lodash.padend": "4.2.0",
-                    "lodash.padstart": "4.2.0"
+                    "ansi": "^0.3.0",
+                    "has-unicode": "^2.0.0",
+                    "lodash.pad": "^4.1.0",
+                    "lodash.padend": "^4.1.0",
+                    "lodash.padstart": "^4.1.0"
                   },
                   "dependencies": {
                     "has-unicode": {
@@ -10742,8 +11371,8 @@
                       "integrity": "sha1-2746loH8y2mXBHOiJj9QwZasOqk=",
                       "dev": true,
                       "requires": {
-                        "lodash.repeat": "4.0.2",
-                        "lodash.tostring": "4.1.2"
+                        "lodash.repeat": "^4.0.0",
+                        "lodash.tostring": "^4.0.0"
                       }
                     },
                     "lodash.padend": {
@@ -10752,8 +11381,8 @@
                       "integrity": "sha1-uE6MNAHUU4BVxuMhpR467hmIGhg=",
                       "dev": true,
                       "requires": {
-                        "lodash.repeat": "4.0.2",
-                        "lodash.tostring": "4.1.2"
+                        "lodash.repeat": "^4.0.0",
+                        "lodash.tostring": "^4.0.0"
                       }
                     },
                     "lodash.padstart": {
@@ -10762,8 +11391,8 @@
                       "integrity": "sha1-42+J/Ww7UHIhkIdpW3Zd6D7JaYU=",
                       "dev": true,
                       "requires": {
-                        "lodash.repeat": "4.0.2",
-                        "lodash.tostring": "4.1.2"
+                        "lodash.repeat": "^4.0.0",
+                        "lodash.tostring": "^4.0.0"
                       }
                     },
                     "lodash.repeat": {
@@ -10772,7 +11401,7 @@
                       "integrity": "sha1-csTkCXV0SMmePEwzSrBmt4nKPzs=",
                       "dev": true,
                       "requires": {
-                        "lodash.tostring": "4.1.2"
+                        "lodash.tostring": "^4.0.0"
                       }
                     },
                     "lodash.tostring": {
@@ -10791,7 +11420,7 @@
               "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
               "requires": {
-                "wrappy": "1.0.1"
+                "wrappy": "1"
               }
             },
             "opener": {
@@ -10806,8 +11435,8 @@
               "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
               "dev": true,
               "requires": {
-                "os-homedir": "1.0.0",
-                "os-tmpdir": "1.0.1"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               },
               "dependencies": {
                 "os-homedir": {
@@ -10830,7 +11459,7 @@
               "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
               "dev": true,
               "requires": {
-                "mute-stream": "0.0.5"
+                "mute-stream": "~0.0.4"
               },
               "dependencies": {
                 "mute-stream": {
@@ -10847,10 +11476,10 @@
               "integrity": "sha1-Ye0bIlbqQ42ACIlQkL6EuOeZyFM=",
               "dev": true,
               "requires": {
-                "glob": "6.0.4",
-                "graceful-fs": "4.1.4",
-                "json-parse-helpfulerror": "1.0.3",
-                "normalize-package-data": "2.3.5"
+                "glob": "^6.0.0",
+                "graceful-fs": "^4.1.2",
+                "json-parse-helpfulerror": "^1.0.2",
+                "normalize-package-data": "^2.0.0"
               },
               "dependencies": {
                 "glob": {
@@ -10859,11 +11488,11 @@
                   "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.1",
-                    "minimatch": "3.0.0",
-                    "once": "1.3.3",
-                    "path-is-absolute": "1.0.0"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "path-is-absolute": {
@@ -10880,7 +11509,7 @@
                   "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                   "dev": true,
                   "requires": {
-                    "jju": "1.3.0"
+                    "jju": "^1.1.0"
                   },
                   "dependencies": {
                     "jju": {
@@ -10899,12 +11528,12 @@
               "integrity": "sha1-qStuhU8T/waF5Mp9zmz3PT4xlCI=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.1",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
               },
               "dependencies": {
                 "core-util-is": {
@@ -10945,27 +11574,27 @@
               "integrity": "sha1-DOOheVEmILEEQfFMguIcEsDdtOE=",
               "dev": true,
               "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.3.2",
-                "bl": "1.1.2",
-                "caseless": "0.11.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.0",
-                "forever-agent": "0.6.1",
-                "form-data": "1.0.0-rc4",
-                "har-validator": "2.0.6",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.11",
-                "node-uuid": "1.4.7",
-                "oauth-sign": "0.8.2",
-                "qs": "6.1.0",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.2.2",
-                "tunnel-agent": "0.4.3"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "bl": "~1.1.2",
+                "caseless": "~0.11.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~1.0.0-rc3",
+                "har-validator": "~2.0.6",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "node-uuid": "~1.4.7",
+                "oauth-sign": "~0.8.1",
+                "qs": "~6.1.0",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.2.0",
+                "tunnel-agent": "~0.4.1"
               },
               "dependencies": {
                 "aws-sign2": {
@@ -10980,7 +11609,7 @@
                   "integrity": "sha1-054L7kEs7Q6O2Uoj4xTzE6lbn9E=",
                   "dev": true,
                   "requires": {
-                    "lru-cache": "4.0.1"
+                    "lru-cache": "^4.0.0"
                   }
                 },
                 "bl": {
@@ -10989,7 +11618,7 @@
                   "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
                   "dev": true,
                   "requires": {
-                    "readable-stream": "2.0.6"
+                    "readable-stream": "~2.0.5"
                   },
                   "dependencies": {
                     "readable-stream": {
@@ -10998,12 +11627,12 @@
                       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                       "dev": true,
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.1",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -11052,7 +11681,7 @@
                   "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
                   "requires": {
-                    "delayed-stream": "1.0.0"
+                    "delayed-stream": "~1.0.0"
                   },
                   "dependencies": {
                     "delayed-stream": {
@@ -11081,9 +11710,9 @@
                   "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
                   "dev": true,
                   "requires": {
-                    "async": "1.5.2",
-                    "combined-stream": "1.0.5",
-                    "mime-types": "2.1.11"
+                    "async": "^1.5.2",
+                    "combined-stream": "^1.0.5",
+                    "mime-types": "^2.1.10"
                   },
                   "dependencies": {
                     "async": {
@@ -11100,10 +11729,10 @@
                   "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
                   "dev": true,
                   "requires": {
-                    "chalk": "1.1.3",
-                    "commander": "2.9.0",
-                    "is-my-json-valid": "2.13.1",
-                    "pinkie-promise": "2.0.1"
+                    "chalk": "^1.1.1",
+                    "commander": "^2.9.0",
+                    "is-my-json-valid": "^2.12.4",
+                    "pinkie-promise": "^2.0.0"
                   },
                   "dependencies": {
                     "chalk": {
@@ -11112,11 +11741,11 @@
                       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                       "dev": true,
                       "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-styles": {
@@ -11137,7 +11766,7 @@
                           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                           "dev": true,
                           "requires": {
-                            "ansi-regex": "2.0.0"
+                            "ansi-regex": "^2.0.0"
                           }
                         },
                         "supports-color": {
@@ -11154,7 +11783,7 @@
                       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                       "dev": true,
                       "requires": {
-                        "graceful-readlink": "1.0.1"
+                        "graceful-readlink": ">= 1.0.0"
                       },
                       "dependencies": {
                         "graceful-readlink": {
@@ -11171,10 +11800,10 @@
                       "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
                       "dev": true,
                       "requires": {
-                        "generate-function": "2.0.0",
-                        "generate-object-property": "1.2.0",
+                        "generate-function": "^2.0.0",
+                        "generate-object-property": "^1.1.0",
                         "jsonpointer": "2.0.0",
-                        "xtend": "4.0.1"
+                        "xtend": "^4.0.0"
                       },
                       "dependencies": {
                         "generate-function": {
@@ -11189,7 +11818,7 @@
                           "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                           "dev": true,
                           "requires": {
-                            "is-property": "1.0.2"
+                            "is-property": "^1.0.0"
                           },
                           "dependencies": {
                             "is-property": {
@@ -11220,7 +11849,7 @@
                       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                       "dev": true,
                       "requires": {
-                        "pinkie": "2.0.4"
+                        "pinkie": "^2.0.0"
                       },
                       "dependencies": {
                         "pinkie": {
@@ -11239,10 +11868,10 @@
                   "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                   "dev": true,
                   "requires": {
-                    "boom": "2.10.1",
-                    "cryptiles": "2.0.5",
-                    "hoek": "2.16.3",
-                    "sntp": "1.0.9"
+                    "boom": "2.x.x",
+                    "cryptiles": "2.x.x",
+                    "hoek": "2.x.x",
+                    "sntp": "1.x.x"
                   },
                   "dependencies": {
                     "boom": {
@@ -11251,7 +11880,7 @@
                       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                       "dev": true,
                       "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                       }
                     },
                     "cryptiles": {
@@ -11260,7 +11889,7 @@
                       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                       "dev": true,
                       "requires": {
-                        "boom": "2.10.1"
+                        "boom": "2.x.x"
                       }
                     },
                     "hoek": {
@@ -11275,7 +11904,7 @@
                       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                       "dev": true,
                       "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                       }
                     }
                   }
@@ -11286,9 +11915,9 @@
                   "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                   "dev": true,
                   "requires": {
-                    "assert-plus": "0.2.0",
-                    "jsprim": "1.2.2",
-                    "sshpk": "1.8.3"
+                    "assert-plus": "^0.2.0",
+                    "jsprim": "^1.2.2",
+                    "sshpk": "^1.7.0"
                   },
                   "dependencies": {
                     "assert-plus": {
@@ -11337,14 +11966,14 @@
                       "integrity": "sha1-iQzJ1hTcUpLlyxpUOwPJq6pcN04=",
                       "dev": true,
                       "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "dashdash": "1.13.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.6",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.0",
-                        "tweetnacl": "0.13.3"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jodid25519": "^1.0.0",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.13.0"
                       },
                       "dependencies": {
                         "asn1": {
@@ -11365,7 +11994,7 @@
                           "integrity": "sha1-NTDtOLkCa+mvBcg0I8kVQSLj1Hw=",
                           "dev": true,
                           "requires": {
-                            "assert-plus": "1.0.0"
+                            "assert-plus": "^1.0.0"
                           }
                         },
                         "ecc-jsbn": {
@@ -11375,7 +12004,7 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "jsbn": "0.1.0"
+                            "jsbn": "~0.1.0"
                           }
                         },
                         "getpass": {
@@ -11384,7 +12013,7 @@
                           "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
                           "dev": true,
                           "requires": {
-                            "assert-plus": "1.0.0"
+                            "assert-plus": "^1.0.0"
                           }
                         },
                         "jodid25519": {
@@ -11394,7 +12023,7 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "jsbn": "0.1.0"
+                            "jsbn": "~0.1.0"
                           }
                         },
                         "jsbn": {
@@ -11439,7 +12068,7 @@
                   "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
                   "dev": true,
                   "requires": {
-                    "mime-db": "1.23.0"
+                    "mime-db": "~1.23.0"
                   },
                   "dependencies": {
                     "mime-db": {
@@ -11500,7 +12129,7 @@
               "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
               "dev": true,
               "requires": {
-                "glob": "7.0.0"
+                "glob": "^7.0.0"
               },
               "dependencies": {
                 "glob": {
@@ -11509,11 +12138,11 @@
                   "integrity": "sha1-OyCjV//89GuzhK7W+K6aZH/basQ=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.1",
-                    "minimatch": "3.0.0",
-                    "once": "1.3.3",
-                    "path-is-absolute": "1.0.0"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "path-is-absolute": {
@@ -11538,8 +12167,8 @@
               "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.4",
-                "readable-stream": "2.0.2"
+                "graceful-fs": "^4.1.2",
+                "readable-stream": "^2.0.2"
               },
               "dependencies": {
                 "readable-stream": {
@@ -11548,12 +12177,12 @@
                   "integrity": "sha1-vsgb6ujPRVFovC5bKzH1vPrtmxs=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.1",
-                    "inherits": "2.0.1",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "process-nextick-args": "1.0.3",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.1"
+                    "process-nextick-args": "~1.0.0",
+                    "string_decoder": "~0.10.x",
+                    "util-deprecate": "~1.0.1"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -11614,7 +12243,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               }
             },
             "uid-number": {
@@ -11635,8 +12264,8 @@
               "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
               "dev": true,
               "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.2"
+                "spdx-correct": "~1.0.0",
+                "spdx-expression-parse": "~1.0.0"
               },
               "dependencies": {
                 "spdx-correct": {
@@ -11645,7 +12274,7 @@
                   "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                   "dev": true,
                   "requires": {
-                    "spdx-license-ids": "1.2.1"
+                    "spdx-license-ids": "^1.0.2"
                   }
                 },
                 "spdx-expression-parse": {
@@ -11654,8 +12283,8 @@
                   "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
                   "dev": true,
                   "requires": {
-                    "spdx-exceptions": "1.0.4",
-                    "spdx-license-ids": "1.2.1"
+                    "spdx-exceptions": "^1.0.4",
+                    "spdx-license-ids": "^1.0.0"
                   },
                   "dependencies": {
                     "spdx-exceptions": {
@@ -11674,8 +12303,8 @@
               "integrity": "sha1-N/qfbqsw5JuO9u6iRoHFeZ1S69Y=",
               "dev": true,
               "requires": {
-                "is-absolute": "0.1.7",
-                "isexe": "1.1.2"
+                "is-absolute": "^0.1.7",
+                "isexe": "^1.1.1"
               },
               "dependencies": {
                 "is-absolute": {
@@ -11684,7 +12313,7 @@
                   "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
                   "dev": true,
                   "requires": {
-                    "is-relative": "0.1.3"
+                    "is-relative": "^0.1.0"
                   },
                   "dependencies": {
                     "is-relative": {
@@ -11717,8 +12346,8 @@
           "integrity": "sha1-gJvGHKv1S9X/lPYWXIm6juiMEVw=",
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
-            "semver": "5.3.0"
+            "hosted-git-info": "^2.1.5",
+            "semver": "^5.1.0"
           },
           "dependencies": {
             "hosted-git-info": {
@@ -11735,10 +12364,10 @@
           "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-spinners": "0.1.2",
-            "object-assign": "4.1.0"
+            "chalk": "^1.1.1",
+            "cli-cursor": "^1.0.2",
+            "cli-spinners": "^0.1.2",
+            "object-assign": "^4.0.1"
           },
           "dependencies": {
             "cli-cursor": {
@@ -11747,7 +12376,7 @@
               "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
               "dev": true,
               "requires": {
-                "restore-cursor": "1.0.1"
+                "restore-cursor": "^1.0.1"
               },
               "dependencies": {
                 "restore-cursor": {
@@ -11756,8 +12385,8 @@
                   "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
                   "dev": true,
                   "requires": {
-                    "exit-hook": "1.1.1",
-                    "onetime": "1.1.0"
+                    "exit-hook": "^1.0.0",
+                    "onetime": "^1.0.0"
                   },
                   "dependencies": {
                     "exit-hook": {
@@ -11796,9 +12425,9 @@
           "integrity": "sha1-ek3p2YVTwxXabx4e0FE47rLRa7g=",
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "debug": "2.3.3",
-            "mkdirp": "0.5.1"
+            "async": "^1.5.2",
+            "debug": "^2.2.0",
+            "mkdirp": "0.5.x"
           },
           "dependencies": {
             "async": {
@@ -11832,7 +12461,7 @@
           "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
           "dev": true,
           "requires": {
-            "rsvp": "3.3.3"
+            "rsvp": "^3.0.14"
           }
         },
         "quick-temp": {
@@ -11841,9 +12470,9 @@
           "integrity": "sha1-DQ1n8PtqWJoOFC+QmF92zbr0A/c=",
           "dev": true,
           "requires": {
-            "mktemp": "0.3.5",
-            "rimraf": "2.2.8",
-            "underscore.string": "2.3.3"
+            "mktemp": "~0.3.4",
+            "rimraf": "~2.2.6",
+            "underscore.string": "~2.3.3"
           },
           "dependencies": {
             "mktemp": {
@@ -11884,12 +12513,12 @@
           "integrity": "sha1-iPdj10BA9fDCVrYWPbOZvxEKxxU=",
           "dev": true,
           "requires": {
-            "exec-sh": "0.2.0",
-            "fb-watchman": "1.9.0",
-            "minimatch": "3.0.3",
-            "minimist": "1.2.0",
-            "walker": "1.0.7",
-            "watch": "0.10.0"
+            "exec-sh": "^0.2.0",
+            "fb-watchman": "^1.8.0",
+            "minimatch": "^3.0.2",
+            "minimist": "^1.1.1",
+            "walker": "~1.0.5",
+            "watch": "~0.10.0"
           },
           "dependencies": {
             "exec-sh": {
@@ -11898,7 +12527,7 @@
               "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
               "dev": true,
               "requires": {
-                "merge": "1.2.0"
+                "merge": "^1.1.3"
               },
               "dependencies": {
                 "merge": {
@@ -11915,7 +12544,7 @@
               "integrity": "sha1-byaPHzR6azyHXR6J2n4e15rfwOw=",
               "dev": true,
               "requires": {
-                "bser": "1.0.2"
+                "bser": "^1.0.2"
               },
               "dependencies": {
                 "bser": {
@@ -11924,7 +12553,7 @@
                   "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
                   "dev": true,
                   "requires": {
-                    "node-int64": "0.4.0"
+                    "node-int64": "^0.4.0"
                   },
                   "dependencies": {
                     "node-int64": {
@@ -11949,7 +12578,7 @@
               "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
               "dev": true,
               "requires": {
-                "makeerror": "1.0.11"
+                "makeerror": "1.0.x"
               },
               "dependencies": {
                 "makeerror": {
@@ -11958,7 +12587,7 @@
                   "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
                   "dev": true,
                   "requires": {
-                    "tmpl": "1.0.4"
+                    "tmpl": "1.0.x"
                   },
                   "dependencies": {
                     "tmpl": {
@@ -11991,7 +12620,7 @@
           "integrity": "sha1-cbfVA9HG+UiCtRtWvoebETy0giw=",
           "dev": true,
           "requires": {
-            "debug": "2.3.3"
+            "debug": "^2.2.0"
           }
         },
         "symlink-or-copy": {
@@ -12006,8 +12635,8 @@
           "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2",
-            "rimraf": "2.2.8"
+            "os-tmpdir": "^1.0.0",
+            "rimraf": "~2.2.6"
           },
           "dependencies": {
             "os-tmpdir": {
@@ -12030,32 +12659,32 @@
           "integrity": "sha1-RBd5s0CvrkvTGNXCvim5nYlklH8=",
           "dev": true,
           "requires": {
-            "backbone": "1.3.3",
-            "bluebird": "3.4.6",
-            "charm": "1.0.2",
-            "commander": "2.9.0",
-            "consolidate": "0.14.5",
-            "cross-spawn": "4.0.2",
+            "backbone": "^1.1.2",
+            "bluebird": "^3.4.6",
+            "charm": "^1.0.0",
+            "commander": "^2.6.0",
+            "consolidate": "^0.14.0",
+            "cross-spawn": "^4.0.0",
             "did_it_work": "0.0.6",
-            "express": "4.14.0",
-            "fireworm": "0.7.1",
-            "glob": "7.1.1",
-            "http-proxy": "1.16.1",
-            "js-yaml": "3.7.0",
-            "lodash.assignin": "4.2.0",
-            "lodash.clonedeep": "4.5.0",
-            "lodash.find": "4.6.0",
-            "mkdirp": "0.5.1",
-            "mustache": "2.3.0",
-            "node-notifier": "4.6.1",
-            "npmlog": "4.0.1",
-            "printf": "0.2.5",
-            "rimraf": "2.5.4",
+            "express": "^4.10.7",
+            "fireworm": "^0.7.0",
+            "glob": "^7.0.4",
+            "http-proxy": "^1.13.1",
+            "js-yaml": "^3.2.5",
+            "lodash.assignin": "^4.1.0",
+            "lodash.clonedeep": "^4.4.1",
+            "lodash.find": "^4.5.1",
+            "mkdirp": "^0.5.1",
+            "mustache": "^2.2.1",
+            "node-notifier": "^4.3.1",
+            "npmlog": "^4.0.0",
+            "printf": "^0.2.3",
+            "rimraf": "^2.4.4",
             "socket.io": "1.5.0",
-            "spawn-args": "0.2.0",
+            "spawn-args": "^0.2.0",
             "styled_string": "0.0.1",
-            "tap-parser": "1.3.2",
-            "xmldom": "0.1.27"
+            "tap-parser": "^1.1.3",
+            "xmldom": "^0.1.19"
           },
           "dependencies": {
             "backbone": {
@@ -12064,7 +12693,7 @@
               "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
               "dev": true,
               "requires": {
-                "underscore": "1.8.3"
+                "underscore": ">=1.8.3"
               },
               "dependencies": {
                 "underscore": {
@@ -12087,7 +12716,7 @@
               "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.3"
+                "inherits": "^2.0.1"
               },
               "dependencies": {
                 "inherits": {
@@ -12104,7 +12733,7 @@
               "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
               "dev": true,
               "requires": {
-                "graceful-readlink": "1.0.1"
+                "graceful-readlink": ">= 1.0.0"
               },
               "dependencies": {
                 "graceful-readlink": {
@@ -12121,7 +12750,7 @@
               "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
               "dev": true,
               "requires": {
-                "bluebird": "3.4.6"
+                "bluebird": "^3.1.1"
               }
             },
             "cross-spawn": {
@@ -12130,8 +12759,8 @@
               "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
               "dev": true,
               "requires": {
-                "lru-cache": "4.0.2",
-                "which": "1.2.12"
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
               },
               "dependencies": {
                 "lru-cache": {
@@ -12140,8 +12769,8 @@
                   "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
                   "dev": true,
                   "requires": {
-                    "pseudomap": "1.0.2",
-                    "yallist": "2.0.0"
+                    "pseudomap": "^1.0.1",
+                    "yallist": "^2.0.0"
                   },
                   "dependencies": {
                     "pseudomap": {
@@ -12164,7 +12793,7 @@
                   "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
                   "dev": true,
                   "requires": {
-                    "isexe": "1.1.2"
+                    "isexe": "^1.1.1"
                   },
                   "dependencies": {
                     "isexe": {
@@ -12189,11 +12818,11 @@
               "integrity": "sha1-zPIPeUHxCIg/zduZOD2+bhhhx1g=",
               "dev": true,
               "requires": {
-                "async": "0.2.10",
+                "async": "~0.2.9",
                 "is-type": "0.0.1",
-                "lodash.debounce": "3.1.1",
-                "lodash.flatten": "3.0.2",
-                "minimatch": "3.0.3"
+                "lodash.debounce": "^3.1.1",
+                "lodash.flatten": "^3.0.2",
+                "minimatch": "^3.0.2"
               },
               "dependencies": {
                 "async": {
@@ -12208,7 +12837,7 @@
                   "integrity": "sha1-9lHYXDZdRJVdFKUdjXBh8/a0d5w=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2"
+                    "core-util-is": "~1.0.0"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -12225,7 +12854,7 @@
                   "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
                   "dev": true,
                   "requires": {
-                    "lodash._getnative": "3.9.1"
+                    "lodash._getnative": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._getnative": {
@@ -12242,8 +12871,8 @@
                   "integrity": "sha1-3hz1d1j49EeTGdNcPpzGDEUBk4w=",
                   "dev": true,
                   "requires": {
-                    "lodash._baseflatten": "3.1.4",
-                    "lodash._isiterateecall": "3.0.9"
+                    "lodash._baseflatten": "^3.0.0",
+                    "lodash._isiterateecall": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._baseflatten": {
@@ -12252,8 +12881,8 @@
                       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
                       "dev": true,
                       "requires": {
-                        "lodash.isarguments": "3.1.0",
-                        "lodash.isarray": "3.0.4"
+                        "lodash.isarguments": "^3.0.0",
+                        "lodash.isarray": "^3.0.0"
                       },
                       "dependencies": {
                         "lodash.isarguments": {
@@ -12286,12 +12915,12 @@
               "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.2",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               },
               "dependencies": {
                 "fs.realpath": {
@@ -12306,8 +12935,8 @@
                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "dev": true,
                   "requires": {
-                    "once": "1.4.0",
-                    "wrappy": "1.0.2"
+                    "once": "^1.3.0",
+                    "wrappy": "1"
                   },
                   "dependencies": {
                     "wrappy": {
@@ -12330,7 +12959,7 @@
                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
                   "requires": {
-                    "wrappy": "1.0.2"
+                    "wrappy": "1"
                   },
                   "dependencies": {
                     "wrappy": {
@@ -12355,8 +12984,8 @@
               "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
               "dev": true,
               "requires": {
-                "argparse": "1.0.9",
-                "esprima": "2.7.3"
+                "argparse": "^1.0.7",
+                "esprima": "^2.6.0"
               },
               "dependencies": {
                 "argparse": {
@@ -12365,7 +12994,7 @@
                   "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
                   "dev": true,
                   "requires": {
-                    "sprintf-js": "1.0.3"
+                    "sprintf-js": "~1.0.2"
                   },
                   "dependencies": {
                     "sprintf-js": {
@@ -12431,13 +13060,13 @@
               "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
               "dev": true,
               "requires": {
-                "cli-usage": "0.1.4",
-                "growly": "1.3.0",
-                "lodash.clonedeep": "3.0.2",
-                "minimist": "1.2.0",
-                "semver": "5.3.0",
-                "shellwords": "0.1.0",
-                "which": "1.2.12"
+                "cli-usage": "^0.1.1",
+                "growly": "^1.2.0",
+                "lodash.clonedeep": "^3.0.0",
+                "minimist": "^1.1.1",
+                "semver": "^5.1.0",
+                "shellwords": "^0.1.0",
+                "which": "^1.0.5"
               },
               "dependencies": {
                 "cli-usage": {
@@ -12446,8 +13075,8 @@
                   "integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
                   "dev": true,
                   "requires": {
-                    "marked": "0.3.6",
-                    "marked-terminal": "1.7.0"
+                    "marked": "^0.3.6",
+                    "marked-terminal": "^1.6.2"
                   },
                   "dependencies": {
                     "marked": {
@@ -12462,11 +13091,11 @@
                       "integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
                       "dev": true,
                       "requires": {
-                        "cardinal": "1.0.0",
-                        "chalk": "1.1.3",
-                        "cli-table": "0.3.1",
-                        "lodash.assign": "4.2.0",
-                        "node-emoji": "1.4.3"
+                        "cardinal": "^1.0.0",
+                        "chalk": "^1.1.3",
+                        "cli-table": "^0.3.1",
+                        "lodash.assign": "^4.2.0",
+                        "node-emoji": "^1.4.1"
                       },
                       "dependencies": {
                         "cardinal": {
@@ -12475,8 +13104,8 @@
                           "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
                           "dev": true,
                           "requires": {
-                            "ansicolors": "0.2.1",
-                            "redeyed": "1.0.1"
+                            "ansicolors": "~0.2.1",
+                            "redeyed": "~1.0.0"
                           },
                           "dependencies": {
                             "ansicolors": {
@@ -12491,7 +13120,7 @@
                               "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
                               "dev": true,
                               "requires": {
-                                "esprima": "3.0.0"
+                                "esprima": "~3.0.0"
                               },
                               "dependencies": {
                                 "esprima": {
@@ -12533,7 +13162,7 @@
                           "integrity": "sha1-UnL3C4I8TfbXw5+E/YID81s+XTY=",
                           "dev": true,
                           "requires": {
-                            "string.prototype.codepointat": "0.2.0"
+                            "string.prototype.codepointat": "^0.2.0"
                           },
                           "dependencies": {
                             "string.prototype.codepointat": {
@@ -12560,8 +13189,8 @@
                   "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
                   "dev": true,
                   "requires": {
-                    "lodash._baseclone": "3.3.0",
-                    "lodash._bindcallback": "3.0.1"
+                    "lodash._baseclone": "^3.0.0",
+                    "lodash._bindcallback": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._baseclone": {
@@ -12570,12 +13199,12 @@
                       "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
                       "dev": true,
                       "requires": {
-                        "lodash._arraycopy": "3.0.0",
-                        "lodash._arrayeach": "3.0.0",
-                        "lodash._baseassign": "3.2.0",
-                        "lodash._basefor": "3.0.3",
-                        "lodash.isarray": "3.0.4",
-                        "lodash.keys": "3.1.2"
+                        "lodash._arraycopy": "^3.0.0",
+                        "lodash._arrayeach": "^3.0.0",
+                        "lodash._baseassign": "^3.0.0",
+                        "lodash._basefor": "^3.0.0",
+                        "lodash.isarray": "^3.0.0",
+                        "lodash.keys": "^3.0.0"
                       },
                       "dependencies": {
                         "lodash._arraycopy": {
@@ -12596,8 +13225,8 @@
                           "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
                           "dev": true,
                           "requires": {
-                            "lodash._basecopy": "3.0.1",
-                            "lodash.keys": "3.1.2"
+                            "lodash._basecopy": "^3.0.0",
+                            "lodash.keys": "^3.0.0"
                           },
                           "dependencies": {
                             "lodash._basecopy": {
@@ -12626,9 +13255,9 @@
                           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
                           "dev": true,
                           "requires": {
-                            "lodash._getnative": "3.9.1",
-                            "lodash.isarguments": "3.1.0",
-                            "lodash.isarray": "3.0.4"
+                            "lodash._getnative": "^3.0.0",
+                            "lodash.isarguments": "^3.0.0",
+                            "lodash.isarray": "^3.0.0"
                           },
                           "dependencies": {
                             "lodash._getnative": {
@@ -12673,7 +13302,7 @@
                   "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
                   "dev": true,
                   "requires": {
-                    "isexe": "1.1.2"
+                    "isexe": "^1.1.1"
                   },
                   "dependencies": {
                     "isexe": {
@@ -12692,10 +13321,10 @@
               "integrity": "sha1-0U9QO0zXlxA3VVMAS6luZmL7wLg=",
               "dev": true,
               "requires": {
-                "are-we-there-yet": "1.1.2",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.2",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.1",
+                "set-blocking": "~2.0.0"
               },
               "dependencies": {
                 "are-we-there-yet": {
@@ -12704,8 +13333,8 @@
                   "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
                   "dev": true,
                   "requires": {
-                    "delegates": "1.0.0",
-                    "readable-stream": "2.2.2"
+                    "delegates": "^1.0.0",
+                    "readable-stream": "^2.0.0 || ^1.1.13"
                   },
                   "dependencies": {
                     "delegates": {
@@ -12720,13 +13349,13 @@
                       "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
                       "dev": true,
                       "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "buffer-shims": "^1.0.0",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                       },
                       "dependencies": {
                         "buffer-shims": {
@@ -12787,15 +13416,15 @@
                   "integrity": "sha1-Fc7MMbAtBTRaXWsOFxzbOtIwd3Q=",
                   "dev": true,
                   "requires": {
-                    "aproba": "1.0.4",
-                    "console-control-strings": "1.1.0",
-                    "has-unicode": "2.0.1",
-                    "object-assign": "4.1.0",
-                    "signal-exit": "3.0.2",
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "0.2.0",
-                    "wide-align": "1.1.0"
+                    "aproba": "^1.0.3",
+                    "console-control-strings": "^1.0.0",
+                    "has-unicode": "^2.0.0",
+                    "object-assign": "^4.1.0",
+                    "signal-exit": "^3.0.0",
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1",
+                    "supports-color": "^0.2.0",
+                    "wide-align": "^1.1.0"
                   },
                   "dependencies": {
                     "aproba": {
@@ -12828,9 +13457,9 @@
                       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                       },
                       "dependencies": {
                         "code-point-at": {
@@ -12845,7 +13474,7 @@
                           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "requires": {
-                            "number-is-nan": "1.0.1"
+                            "number-is-nan": "^1.0.0"
                           },
                           "dependencies": {
                             "number-is-nan": {
@@ -12864,7 +13493,7 @@
                       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -12887,7 +13516,7 @@
                       "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
                       "dev": true,
                       "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.1"
                       }
                     }
                   }
@@ -12912,7 +13541,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               }
             },
             "socket.io": {
@@ -12965,7 +13594,7 @@
                       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
                       "dev": true,
                       "requires": {
-                        "mime-types": "2.1.13",
+                        "mime-types": "~2.1.11",
                         "negotiator": "0.6.1"
                       },
                       "dependencies": {
@@ -12975,7 +13604,7 @@
                           "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
                           "dev": true,
                           "requires": {
-                            "mime-db": "1.25.0"
+                            "mime-db": "~1.25.0"
                           },
                           "dependencies": {
                             "mime-db": {
@@ -13069,8 +13698,8 @@
                       "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
                       "dev": true,
                       "requires": {
-                        "options": "0.0.6",
-                        "ultron": "1.0.2"
+                        "options": ">=0.0.5",
+                        "ultron": "1.0.x"
                       },
                       "dependencies": {
                         "options": {
@@ -13307,7 +13936,7 @@
                           "integrity": "sha1-mxDGwNglq1ieaFFTgm3go7oni8w=",
                           "dev": true,
                           "requires": {
-                            "better-assert": "1.0.2"
+                            "better-assert": "~1.0.0"
                           },
                           "dependencies": {
                             "better-assert": {
@@ -13335,7 +13964,7 @@
                           "integrity": "sha1-nf5wss3aw4i95PNbHyQPpYrb5sc=",
                           "dev": true,
                           "requires": {
-                            "better-assert": "1.0.2"
+                            "better-assert": "~1.0.0"
                           },
                           "dependencies": {
                             "better-assert": {
@@ -13363,8 +13992,8 @@
                           "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
                           "dev": true,
                           "requires": {
-                            "options": "0.0.6",
-                            "ultron": "1.0.2"
+                            "options": ">=0.0.5",
+                            "ultron": "1.0.x"
                           },
                           "dependencies": {
                             "options": {
@@ -13413,7 +14042,7 @@
                       "integrity": "sha1-gGWCo5iH4eoY3V4v4OAZAiaOk1A=",
                       "dev": true,
                       "requires": {
-                        "better-assert": "1.0.2"
+                        "better-assert": "~1.0.0"
                       },
                       "dependencies": {
                         "better-assert": {
@@ -13502,10 +14131,10 @@
               "integrity": "sha1-EgxQiciMPIp5PvKIhn3jIeGPjCI=",
               "dev": true,
               "requires": {
-                "events-to-array": "1.0.2",
-                "inherits": "2.0.3",
-                "js-yaml": "3.7.0",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
+                "events-to-array": "^1.0.1",
+                "inherits": "~2.0.1",
+                "js-yaml": "^3.2.7",
+                "readable-stream": "^2"
               },
               "dependencies": {
                 "events-to-array": {
@@ -13542,12 +14171,12 @@
           "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
           "dev": true,
           "requires": {
-            "body-parser": "1.14.2",
-            "debug": "2.2.0",
-            "faye-websocket": "0.10.0",
-            "livereload-js": "2.2.2",
-            "parseurl": "1.3.1",
-            "qs": "5.1.0"
+            "body-parser": "~1.14.0",
+            "debug": "~2.2.0",
+            "faye-websocket": "~0.10.0",
+            "livereload-js": "^2.2.0",
+            "parseurl": "~1.3.0",
+            "qs": "~5.1.0"
           },
           "dependencies": {
             "body-parser": {
@@ -13557,15 +14186,15 @@
               "dev": true,
               "requires": {
                 "bytes": "2.2.0",
-                "content-type": "1.0.2",
-                "debug": "2.2.0",
-                "depd": "1.1.0",
-                "http-errors": "1.3.1",
+                "content-type": "~1.0.1",
+                "debug": "~2.2.0",
+                "depd": "~1.1.0",
+                "http-errors": "~1.3.1",
                 "iconv-lite": "0.4.13",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "5.2.0",
-                "raw-body": "2.1.7",
-                "type-is": "1.6.14"
+                "raw-body": "~2.1.5",
+                "type-is": "~1.6.10"
               },
               "dependencies": {
                 "bytes": {
@@ -13592,8 +14221,8 @@
                   "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
                   "dev": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "statuses": "1.3.1"
+                    "inherits": "~2.0.1",
+                    "statuses": "1"
                   },
                   "dependencies": {
                     "inherits": {
@@ -13671,7 +14300,7 @@
                   "dev": true,
                   "requires": {
                     "media-typer": "0.3.0",
-                    "mime-types": "2.1.13"
+                    "mime-types": "~2.1.13"
                   },
                   "dependencies": {
                     "media-typer": {
@@ -13686,7 +14315,7 @@
                       "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
                       "dev": true,
                       "requires": {
-                        "mime-db": "1.25.0"
+                        "mime-db": "~1.25.0"
                       },
                       "dependencies": {
                         "mime-db": {
@@ -13724,7 +14353,7 @@
               "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
               "dev": true,
               "requires": {
-                "websocket-driver": "0.6.5"
+                "websocket-driver": ">=0.5.1"
               },
               "dependencies": {
                 "websocket-driver": {
@@ -13733,7 +14362,7 @@
                   "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
                   "dev": true,
                   "requires": {
-                    "websocket-extensions": "0.1.1"
+                    "websocket-extensions": ">=0.1.1"
                   },
                   "dependencies": {
                     "websocket-extensions": {
@@ -13772,11 +14401,11 @@
           "integrity": "sha1-PMtcfAv68fq03YndSCBqsrQTvnI=",
           "dev": true,
           "requires": {
-            "debug": "2.3.3",
-            "fs-tree-diff": "0.5.5",
-            "mkdirp": "0.5.1",
-            "quick-temp": "0.1.5",
-            "walk-sync": "0.2.7"
+            "debug": "^2.2.0",
+            "fs-tree-diff": "^0.5.2",
+            "mkdirp": "^0.5.1",
+            "quick-temp": "^0.1.5",
+            "walk-sync": "^0.2.7"
           },
           "dependencies": {
             "fs-tree-diff": {
@@ -13785,10 +14414,10 @@
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "dev": true,
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "heimdalljs-logger": {
@@ -13797,8 +14426,8 @@
                   "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
+                    "debug": "^2.2.0",
+                    "heimdalljs": "^0.2.0"
                   },
                   "dependencies": {
                     "heimdalljs": {
@@ -13807,7 +14436,7 @@
                       "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
                       "dev": true,
                       "requires": {
-                        "rsvp": "3.2.1"
+                        "rsvp": "~3.2.1"
                       },
                       "dependencies": {
                         "rsvp": {
@@ -13859,8 +14488,8 @@
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
           "dev": true,
           "requires": {
-            "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.4"
+            "ensure-posix-path": "^1.0.0",
+            "matcher-collection": "^1.0.0"
           },
           "dependencies": {
             "ensure-posix-path": {
@@ -13875,7 +14504,7 @@
               "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
               "dev": true,
               "requires": {
-                "minimatch": "3.0.3"
+                "minimatch": "^3.0.2"
               }
             }
           }
@@ -13886,9 +14515,9 @@
           "integrity": "sha1-JhdgsBdUpcNzGiKo35qM18nM7aY=",
           "dev": true,
           "requires": {
-            "findup": "0.1.5",
-            "fs-extra": "0.26.7",
-            "lodash.merge": "3.3.2"
+            "findup": "^0.1.5",
+            "fs-extra": "^0.26.6",
+            "lodash.merge": "^3.0.2"
           },
           "dependencies": {
             "findup": {
@@ -13897,8 +14526,8 @@
               "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
               "dev": true,
               "requires": {
-                "colors": "0.6.2",
-                "commander": "2.1.0"
+                "colors": "~0.6.0-1",
+                "commander": "~2.1.0"
               },
               "dependencies": {
                 "colors": {
@@ -13921,11 +14550,11 @@
               "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "2.4.0",
-                "klaw": "1.3.1",
-                "path-is-absolute": "1.0.1",
-                "rimraf": "2.5.4"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
               },
               "dependencies": {
                 "graceful-fs": {
@@ -13940,7 +14569,7 @@
                   "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11"
+                    "graceful-fs": "^4.1.6"
                   }
                 },
                 "klaw": {
@@ -13949,7 +14578,7 @@
                   "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11"
+                    "graceful-fs": "^4.1.9"
                   }
                 },
                 "path-is-absolute": {
@@ -13964,7 +14593,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -13973,12 +14602,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -13993,8 +14622,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -14017,7 +14646,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -14040,17 +14669,17 @@
               "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
               "dev": true,
               "requires": {
-                "lodash._arraycopy": "3.0.0",
-                "lodash._arrayeach": "3.0.0",
-                "lodash._createassigner": "3.1.1",
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4",
-                "lodash.isplainobject": "3.2.0",
-                "lodash.istypedarray": "3.0.6",
-                "lodash.keys": "3.1.2",
-                "lodash.keysin": "3.0.8",
-                "lodash.toplainobject": "3.0.0"
+                "lodash._arraycopy": "^3.0.0",
+                "lodash._arrayeach": "^3.0.0",
+                "lodash._createassigner": "^3.0.0",
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.isplainobject": "^3.0.0",
+                "lodash.istypedarray": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.keysin": "^3.0.0",
+                "lodash.toplainobject": "^3.0.0"
               },
               "dependencies": {
                 "lodash._arraycopy": {
@@ -14071,9 +14700,9 @@
                   "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
                   "dev": true,
                   "requires": {
-                    "lodash._bindcallback": "3.0.1",
-                    "lodash._isiterateecall": "3.0.9",
-                    "lodash.restparam": "3.6.1"
+                    "lodash._bindcallback": "^3.0.0",
+                    "lodash._isiterateecall": "^3.0.0",
+                    "lodash.restparam": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._bindcallback": {
@@ -14120,9 +14749,9 @@
                   "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
                   "dev": true,
                   "requires": {
-                    "lodash._basefor": "3.0.3",
-                    "lodash.isarguments": "3.1.0",
-                    "lodash.keysin": "3.0.8"
+                    "lodash._basefor": "^3.0.0",
+                    "lodash.isarguments": "^3.0.0",
+                    "lodash.keysin": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._basefor": {
@@ -14145,9 +14774,9 @@
                   "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
                   "dev": true,
                   "requires": {
-                    "lodash._getnative": "3.9.1",
-                    "lodash.isarguments": "3.1.0",
-                    "lodash.isarray": "3.0.4"
+                    "lodash._getnative": "^3.0.0",
+                    "lodash.isarguments": "^3.0.0",
+                    "lodash.isarray": "^3.0.0"
                   }
                 },
                 "lodash.keysin": {
@@ -14156,8 +14785,8 @@
                   "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
                   "dev": true,
                   "requires": {
-                    "lodash.isarguments": "3.1.0",
-                    "lodash.isarray": "3.0.4"
+                    "lodash.isarguments": "^3.0.0",
+                    "lodash.isarray": "^3.0.0"
                   }
                 },
                 "lodash.toplainobject": {
@@ -14166,8 +14795,8 @@
                   "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
                   "dev": true,
                   "requires": {
-                    "lodash._basecopy": "3.0.1",
-                    "lodash.keysin": "3.0.8"
+                    "lodash._basecopy": "^3.0.0",
+                    "lodash.keysin": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._basecopy": {
@@ -14190,8 +14819,8 @@
       "integrity": "sha1-0TXrp18w55HYpeWETxJR3LzEBDg=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "5.1.10",
-        "ember-cli-htmlbars": "1.1.1",
+        "ember-cli-babel": "^5.1.6",
+        "ember-cli-htmlbars": "^1.0.0",
         "git-repo-version": "0.3.0"
       },
       "dependencies": {
@@ -14201,7 +14830,7 @@
           "integrity": "sha1-ybl9DSHENX1mncEmnCtqddpswOk=",
           "dev": true,
           "requires": {
-            "git-repo-info": "1.3.1"
+            "git-repo-info": "^1.0.4"
           },
           "dependencies": {
             "git-repo-info": {
@@ -14219,11 +14848,11 @@
       "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.1.10.tgz",
       "integrity": "sha1-1APxeKq2AuEzfEA8WljAIAqJaao=",
       "requires": {
-        "broccoli-babel-transpiler": "5.6.1",
-        "broccoli-funnel": "1.1.0",
-        "clone": "1.0.2",
-        "ember-cli-version-checker": "1.2.0",
-        "resolve": "1.1.7"
+        "broccoli-babel-transpiler": "^5.6.0",
+        "broccoli-funnel": "^1.0.0",
+        "clone": "^1.0.2",
+        "ember-cli-version-checker": "^1.0.2",
+        "resolve": "^1.1.2"
       },
       "dependencies": {
         "broccoli-babel-transpiler": {
@@ -14231,13 +14860,13 @@
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.6.1.tgz",
           "integrity": "sha1-lxhNyxQLQKpX8/84Mwr8zGddCjw=",
           "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.1.0",
-            "broccoli-merge-trees": "1.2.1",
-            "broccoli-persistent-filter": "1.2.11",
-            "clone": "0.2.0",
-            "hash-for-dep": "1.0.3",
-            "json-stable-stringify": "1.0.1"
+            "babel-core": "^5.0.0",
+            "broccoli-funnel": "^1.0.0",
+            "broccoli-merge-trees": "^1.0.0",
+            "broccoli-persistent-filter": "^1.0.1",
+            "clone": "^0.2.0",
+            "hash-for-dep": "^1.0.2",
+            "json-stable-stringify": "^1.0.0"
           },
           "dependencies": {
             "babel-core": {
@@ -14245,52 +14874,52 @@
               "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
               "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
               "requires": {
-                "babel-plugin-constant-folding": "1.0.1",
-                "babel-plugin-dead-code-elimination": "1.0.2",
-                "babel-plugin-eval": "1.0.1",
-                "babel-plugin-inline-environment-variables": "1.0.1",
-                "babel-plugin-jscript": "1.0.4",
-                "babel-plugin-member-expression-literals": "1.0.1",
-                "babel-plugin-property-literals": "1.0.1",
-                "babel-plugin-proto-to-assign": "1.0.4",
-                "babel-plugin-react-constant-elements": "1.0.3",
-                "babel-plugin-react-display-name": "1.0.3",
-                "babel-plugin-remove-console": "1.0.1",
-                "babel-plugin-remove-debugger": "1.0.1",
-                "babel-plugin-runtime": "1.0.7",
-                "babel-plugin-undeclared-variables-check": "1.0.2",
-                "babel-plugin-undefined-to-void": "1.1.6",
-                "babylon": "5.8.38",
-                "bluebird": "2.11.0",
-                "chalk": "1.1.3",
-                "convert-source-map": "1.3.0",
-                "core-js": "1.2.7",
-                "debug": "2.3.3",
-                "detect-indent": "3.0.1",
-                "esutils": "2.0.2",
-                "fs-readdir-recursive": "0.1.2",
-                "globals": "6.4.1",
-                "home-or-tmp": "1.0.0",
-                "is-integer": "1.0.6",
+                "babel-plugin-constant-folding": "^1.0.1",
+                "babel-plugin-dead-code-elimination": "^1.0.2",
+                "babel-plugin-eval": "^1.0.1",
+                "babel-plugin-inline-environment-variables": "^1.0.1",
+                "babel-plugin-jscript": "^1.0.4",
+                "babel-plugin-member-expression-literals": "^1.0.1",
+                "babel-plugin-property-literals": "^1.0.1",
+                "babel-plugin-proto-to-assign": "^1.0.3",
+                "babel-plugin-react-constant-elements": "^1.0.3",
+                "babel-plugin-react-display-name": "^1.0.3",
+                "babel-plugin-remove-console": "^1.0.1",
+                "babel-plugin-remove-debugger": "^1.0.1",
+                "babel-plugin-runtime": "^1.0.7",
+                "babel-plugin-undeclared-variables-check": "^1.0.2",
+                "babel-plugin-undefined-to-void": "^1.1.6",
+                "babylon": "^5.8.38",
+                "bluebird": "^2.9.33",
+                "chalk": "^1.0.0",
+                "convert-source-map": "^1.1.0",
+                "core-js": "^1.0.0",
+                "debug": "^2.1.1",
+                "detect-indent": "^3.0.0",
+                "esutils": "^2.0.0",
+                "fs-readdir-recursive": "^0.1.0",
+                "globals": "^6.4.0",
+                "home-or-tmp": "^1.0.0",
+                "is-integer": "^1.0.4",
                 "js-tokens": "1.0.1",
-                "json5": "0.4.0",
-                "lodash": "3.10.1",
-                "minimatch": "2.0.10",
-                "output-file-sync": "1.1.2",
-                "path-exists": "1.0.0",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.6",
+                "json5": "^0.4.0",
+                "lodash": "^3.10.0",
+                "minimatch": "^2.0.3",
+                "output-file-sync": "^1.1.0",
+                "path-exists": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "private": "^0.1.6",
                 "regenerator": "0.8.40",
-                "regexpu": "1.3.0",
-                "repeating": "1.1.3",
-                "resolve": "1.1.7",
-                "shebang-regex": "1.0.0",
-                "slash": "1.0.0",
-                "source-map": "0.5.6",
-                "source-map-support": "0.2.10",
-                "to-fast-properties": "1.0.2",
-                "trim-right": "1.0.1",
-                "try-resolve": "1.0.1"
+                "regexpu": "^1.3.0",
+                "repeating": "^1.1.2",
+                "resolve": "^1.1.6",
+                "shebang-regex": "^1.0.0",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.0",
+                "source-map-support": "^0.2.10",
+                "to-fast-properties": "^1.0.0",
+                "trim-right": "^1.0.0",
+                "try-resolve": "^1.0.0"
               },
               "dependencies": {
                 "babel-plugin-constant-folding": {
@@ -14333,7 +14962,7 @@
                   "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
                   "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
                   "requires": {
-                    "lodash": "3.10.1"
+                    "lodash": "^3.9.3"
                   }
                 },
                 "babel-plugin-react-constant-elements": {
@@ -14366,7 +14995,7 @@
                   "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
                   "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
                   "requires": {
-                    "leven": "1.0.2"
+                    "leven": "^1.0.2"
                   },
                   "dependencies": {
                     "leven": {
@@ -14396,11 +15025,11 @@
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
+                    "ansi-styles": "^2.2.1",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -14418,7 +15047,7 @@
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -14433,7 +15062,7 @@
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -14480,9 +15109,9 @@
                   "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
                   "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
                   "requires": {
-                    "get-stdin": "4.0.1",
-                    "minimist": "1.2.0",
-                    "repeating": "1.1.3"
+                    "get-stdin": "^4.0.1",
+                    "minimist": "^1.1.0",
+                    "repeating": "^1.1.0"
                   },
                   "dependencies": {
                     "get-stdin": {
@@ -14517,8 +15146,8 @@
                   "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
                   "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
                   "requires": {
-                    "os-tmpdir": "1.0.2",
-                    "user-home": "1.1.1"
+                    "os-tmpdir": "^1.0.1",
+                    "user-home": "^1.1.1"
                   },
                   "dependencies": {
                     "os-tmpdir": {
@@ -14538,7 +15167,7 @@
                   "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
                   "integrity": "sha1-UnOBn62ogNEj4awAqTjnFy3Y2V4=",
                   "requires": {
-                    "is-finite": "1.0.2"
+                    "is-finite": "^1.0.0"
                   },
                   "dependencies": {
                     "is-finite": {
@@ -14546,7 +15175,7 @@
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
                       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -14578,7 +15207,7 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                   "requires": {
-                    "brace-expansion": "1.1.6"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -14586,7 +15215,7 @@
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -14609,9 +15238,9 @@
                   "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
                   "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
                   "requires": {
-                    "graceful-fs": "4.1.11",
-                    "mkdirp": "0.5.1",
-                    "object-assign": "4.1.0"
+                    "graceful-fs": "^4.1.4",
+                    "mkdirp": "^0.5.1",
+                    "object-assign": "^4.1.0"
                   },
                   "dependencies": {
                     "graceful-fs": {
@@ -14661,12 +15290,12 @@
                   "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
                   "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
                   "requires": {
-                    "commoner": "0.10.8",
-                    "defs": "1.1.1",
-                    "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                    "private": "0.1.6",
+                    "commoner": "~0.10.3",
+                    "defs": "~1.1.0",
+                    "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                    "private": "~0.1.5",
                     "recast": "0.10.33",
-                    "through": "2.3.8"
+                    "through": "~2.3.8"
                   },
                   "dependencies": {
                     "commoner": {
@@ -14674,15 +15303,15 @@
                       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
                       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
                       "requires": {
-                        "commander": "2.9.0",
-                        "detective": "4.3.2",
-                        "glob": "5.0.15",
-                        "graceful-fs": "4.1.11",
-                        "iconv-lite": "0.4.15",
-                        "mkdirp": "0.5.1",
-                        "private": "0.1.6",
-                        "q": "1.4.1",
-                        "recast": "0.11.18"
+                        "commander": "^2.5.0",
+                        "detective": "^4.3.1",
+                        "glob": "^5.0.15",
+                        "graceful-fs": "^4.1.2",
+                        "iconv-lite": "^0.4.5",
+                        "mkdirp": "^0.5.0",
+                        "private": "^0.1.6",
+                        "q": "^1.1.2",
+                        "recast": "^0.11.17"
                       },
                       "dependencies": {
                         "commander": {
@@ -14690,7 +15319,7 @@
                           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                           "requires": {
-                            "graceful-readlink": "1.0.1"
+                            "graceful-readlink": ">= 1.0.0"
                           },
                           "dependencies": {
                             "graceful-readlink": {
@@ -14705,8 +15334,8 @@
                           "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz",
                           "integrity": "sha1-d2l+LnlHrD/nyOJqbW8RUjWvqRw=",
                           "requires": {
-                            "acorn": "3.3.0",
-                            "defined": "1.0.0"
+                            "acorn": "^3.1.0",
+                            "defined": "^1.0.0"
                           },
                           "dependencies": {
                             "acorn": {
@@ -14726,11 +15355,11 @@
                           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                           "requires": {
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "2.0.10",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "2 || 3",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "inflight": {
@@ -14738,8 +15367,8 @@
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -14759,7 +15388,7 @@
                               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -14807,9 +15436,9 @@
                           "integrity": "sha1-B69iV8p2mGiBUglAHU1g7vG1uUc=",
                           "requires": {
                             "ast-types": "0.9.2",
-                            "esprima": "3.1.2",
-                            "private": "0.1.6",
-                            "source-map": "0.5.6"
+                            "esprima": "~3.1.0",
+                            "private": "~0.1.5",
+                            "source-map": "~0.5.0"
                           },
                           "dependencies": {
                             "ast-types": {
@@ -14831,16 +15460,16 @@
                       "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
                       "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
                       "requires": {
-                        "alter": "0.2.0",
-                        "ast-traverse": "0.1.1",
-                        "breakable": "1.0.0",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "simple-fmt": "0.1.0",
-                        "simple-is": "0.2.0",
-                        "stringmap": "0.2.2",
-                        "stringset": "0.2.1",
-                        "tryor": "0.1.2",
-                        "yargs": "3.27.0"
+                        "alter": "~0.2.0",
+                        "ast-traverse": "~0.1.1",
+                        "breakable": "~1.0.0",
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "simple-fmt": "~0.1.0",
+                        "simple-is": "~0.2.0",
+                        "stringmap": "~0.2.2",
+                        "stringset": "~0.2.1",
+                        "tryor": "~0.1.2",
+                        "yargs": "~3.27.0"
                       },
                       "dependencies": {
                         "alter": {
@@ -14848,7 +15477,7 @@
                           "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                           "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
                           "requires": {
-                            "stable": "0.1.5"
+                            "stable": "~0.1.3"
                           },
                           "dependencies": {
                             "stable": {
@@ -14898,12 +15527,12 @@
                           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
                           "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
                           "requires": {
-                            "camelcase": "1.2.1",
-                            "cliui": "2.1.0",
-                            "decamelize": "1.2.0",
-                            "os-locale": "1.4.0",
-                            "window-size": "0.1.4",
-                            "y18n": "3.2.1"
+                            "camelcase": "^1.2.1",
+                            "cliui": "^2.1.0",
+                            "decamelize": "^1.0.0",
+                            "os-locale": "^1.4.0",
+                            "window-size": "^0.1.2",
+                            "y18n": "^3.2.0"
                           },
                           "dependencies": {
                             "camelcase": {
@@ -14916,8 +15545,8 @@
                               "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                               "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                               "requires": {
-                                "center-align": "0.1.3",
-                                "right-align": "0.1.3",
+                                "center-align": "^0.1.1",
+                                "right-align": "^0.1.1",
                                 "wordwrap": "0.0.2"
                               },
                               "dependencies": {
@@ -14926,8 +15555,8 @@
                                   "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                                   "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                                   "requires": {
-                                    "align-text": "0.1.4",
-                                    "lazy-cache": "1.0.4"
+                                    "align-text": "^0.1.3",
+                                    "lazy-cache": "^1.0.3"
                                   },
                                   "dependencies": {
                                     "align-text": {
@@ -14935,9 +15564,9 @@
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                                       "requires": {
-                                        "kind-of": "3.0.4",
-                                        "longest": "1.0.1",
-                                        "repeat-string": "1.6.1"
+                                        "kind-of": "^3.0.2",
+                                        "longest": "^1.0.1",
+                                        "repeat-string": "^1.5.2"
                                       },
                                       "dependencies": {
                                         "kind-of": {
@@ -14945,7 +15574,7 @@
                                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
                                           "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
                                           "requires": {
-                                            "is-buffer": "1.1.4"
+                                            "is-buffer": "^1.0.2"
                                           },
                                           "dependencies": {
                                             "is-buffer": {
@@ -14979,7 +15608,7 @@
                                   "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                                   "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                                   "requires": {
-                                    "align-text": "0.1.4"
+                                    "align-text": "^0.1.1"
                                   },
                                   "dependencies": {
                                     "align-text": {
@@ -14987,9 +15616,9 @@
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                                       "requires": {
-                                        "kind-of": "3.0.4",
-                                        "longest": "1.0.1",
-                                        "repeat-string": "1.6.1"
+                                        "kind-of": "^3.0.2",
+                                        "longest": "^1.0.1",
+                                        "repeat-string": "^1.5.2"
                                       },
                                       "dependencies": {
                                         "kind-of": {
@@ -14997,7 +15626,7 @@
                                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
                                           "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
                                           "requires": {
-                                            "is-buffer": "1.1.4"
+                                            "is-buffer": "^1.0.2"
                                           },
                                           "dependencies": {
                                             "is-buffer": {
@@ -15038,7 +15667,7 @@
                               "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                               "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
                               "requires": {
-                                "lcid": "1.0.0"
+                                "lcid": "^1.0.0"
                               },
                               "dependencies": {
                                 "lcid": {
@@ -15046,7 +15675,7 @@
                                   "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                                   "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                                   "requires": {
-                                    "invert-kv": "1.0.0"
+                                    "invert-kv": "^1.0.0"
                                   },
                                   "dependencies": {
                                     "invert-kv": {
@@ -15083,9 +15712,9 @@
                       "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
                       "requires": {
                         "ast-types": "0.8.12",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "private": "0.1.6",
-                        "source-map": "0.5.6"
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "private": "~0.1.5",
+                        "source-map": "~0.5.0"
                       },
                       "dependencies": {
                         "ast-types": {
@@ -15107,11 +15736,11 @@
                   "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
                   "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
                   "requires": {
-                    "esprima": "2.7.3",
-                    "recast": "0.10.43",
-                    "regenerate": "1.3.2",
-                    "regjsgen": "0.2.0",
-                    "regjsparser": "0.1.5"
+                    "esprima": "^2.6.0",
+                    "recast": "^0.10.10",
+                    "regenerate": "^1.2.1",
+                    "regjsgen": "^0.2.0",
+                    "regjsparser": "^0.1.4"
                   },
                   "dependencies": {
                     "esprima": {
@@ -15125,9 +15754,9 @@
                       "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
                       "requires": {
                         "ast-types": "0.8.15",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "private": "0.1.6",
-                        "source-map": "0.5.6"
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "private": "~0.1.5",
+                        "source-map": "~0.5.0"
                       },
                       "dependencies": {
                         "ast-types": {
@@ -15157,7 +15786,7 @@
                       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
                       "requires": {
-                        "jsesc": "0.5.0"
+                        "jsesc": "~0.5.0"
                       },
                       "dependencies": {
                         "jsesc": {
@@ -15174,7 +15803,7 @@
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
                   "requires": {
-                    "is-finite": "1.0.2"
+                    "is-finite": "^1.0.0"
                   },
                   "dependencies": {
                     "is-finite": {
@@ -15182,7 +15811,7 @@
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
                       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -15222,7 +15851,7 @@
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
                       "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
                       "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                       },
                       "dependencies": {
                         "amdefine": {
@@ -15256,14 +15885,14 @@
               "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.1.tgz",
               "integrity": "sha1-FqdJTtVtvmFhH2wtSBfPuq0qMFU=",
               "requires": {
-                "broccoli-plugin": "1.3.0",
-                "can-symlink": "1.0.0",
-                "fast-ordered-set": "1.0.3",
-                "fs-tree-diff": "0.5.5",
-                "heimdalljs": "0.2.3",
-                "heimdalljs-logger": "0.1.7",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "broccoli-plugin": "^1.3.0",
+                "can-symlink": "^1.0.0",
+                "fast-ordered-set": "^1.0.2",
+                "fs-tree-diff": "^0.5.4",
+                "heimdalljs": "^0.2.1",
+                "heimdalljs-logger": "^0.1.7",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0"
               },
               "dependencies": {
                 "broccoli-plugin": {
@@ -15271,10 +15900,10 @@
                   "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
                   "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
                   "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.6",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
+                    "promise-map-series": "^0.2.1",
+                    "quick-temp": "^0.1.3",
+                    "rimraf": "^2.3.4",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "promise-map-series": {
@@ -15282,7 +15911,7 @@
                       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
                       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                       "requires": {
-                        "rsvp": "3.3.3"
+                        "rsvp": "^3.0.14"
                       },
                       "dependencies": {
                         "rsvp": {
@@ -15297,9 +15926,9 @@
                       "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.6.tgz",
                       "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                       "requires": {
-                        "mktemp": "0.4.0",
-                        "rimraf": "2.2.8",
-                        "underscore.string": "2.3.3"
+                        "mktemp": "~0.4.0",
+                        "rimraf": "~2.2.6",
+                        "underscore.string": "~2.3.3"
                       },
                       "dependencies": {
                         "mktemp": {
@@ -15334,7 +15963,7 @@
                       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
                       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
                       "requires": {
-                        "os-tmpdir": "1.0.2"
+                        "os-tmpdir": "~1.0.1"
                       },
                       "dependencies": {
                         "os-tmpdir": {
@@ -15351,7 +15980,7 @@
                   "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
                   "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
                   "requires": {
-                    "blank-object": "1.0.2"
+                    "blank-object": "^1.0.1"
                   },
                   "dependencies": {
                     "blank-object": {
@@ -15366,10 +15995,10 @@
                   "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.5.tgz",
                   "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
                   "requires": {
-                    "heimdalljs-logger": "0.1.7",
-                    "object-assign": "4.1.0",
-                    "path-posix": "1.0.0",
-                    "symlink-or-copy": "1.1.8"
+                    "heimdalljs-logger": "^0.1.7",
+                    "object-assign": "^4.1.0",
+                    "path-posix": "^1.0.0",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "object-assign": {
@@ -15389,7 +16018,7 @@
                   "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.3.tgz",
                   "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
                   "requires": {
-                    "rsvp": "3.2.1"
+                    "rsvp": "~3.2.1"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -15404,8 +16033,8 @@
                   "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.7.tgz",
                   "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                   "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
+                    "debug": "^2.2.0",
+                    "heimdalljs": "^0.2.0"
                   },
                   "dependencies": {
                     "debug": {
@@ -15430,7 +16059,7 @@
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -15438,12 +16067,12 @@
                       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -15456,8 +16085,8 @@
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -15477,7 +16106,7 @@
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -15485,7 +16114,7 @@
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -15508,7 +16137,7 @@
                           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -15539,19 +16168,19 @@
               "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.11.tgz",
               "integrity": "sha1-lcxrCw6w3M5fjmrhj2o8xFoGv0A=",
               "requires": {
-                "async-disk-cache": "1.0.9",
-                "blank-object": "1.0.2",
-                "broccoli-plugin": "1.3.0",
-                "fs-tree-diff": "0.5.5",
-                "hash-for-dep": "1.0.3",
-                "heimdalljs": "0.2.3",
-                "heimdalljs-logger": "0.1.7",
-                "md5-hex": "1.3.0",
-                "mkdirp": "0.5.1",
-                "promise-map-series": "0.2.3",
-                "rsvp": "3.3.3",
-                "symlink-or-copy": "1.1.8",
-                "walk-sync": "0.3.1"
+                "async-disk-cache": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.0.0",
+                "fs-tree-diff": "^0.5.2",
+                "hash-for-dep": "^1.0.2",
+                "heimdalljs": "^0.2.1",
+                "heimdalljs-logger": "^0.1.7",
+                "md5-hex": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "promise-map-series": "^0.2.1",
+                "rsvp": "^3.0.18",
+                "symlink-or-copy": "^1.0.1",
+                "walk-sync": "^0.3.1"
               },
               "dependencies": {
                 "async-disk-cache": {
@@ -15559,11 +16188,11 @@
                   "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.9.tgz",
                   "integrity": "sha1-I7r7gjGE9GNAfkdOjV+HiZ9yymM=",
                   "requires": {
-                    "debug": "2.3.3",
+                    "debug": "^2.1.3",
                     "istextorbinary": "2.1.0",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.5.4",
-                    "rsvp": "3.3.3"
+                    "mkdirp": "^0.5.0",
+                    "rimraf": "^2.5.3",
+                    "rsvp": "^3.0.18"
                   },
                   "dependencies": {
                     "debug": {
@@ -15586,9 +16215,9 @@
                       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
                       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
                       "requires": {
-                        "binaryextensions": "2.0.0",
-                        "editions": "1.3.3",
-                        "textextensions": "2.0.1"
+                        "binaryextensions": "1 || 2",
+                        "editions": "^1.1.1",
+                        "textextensions": "1 || 2"
                       },
                       "dependencies": {
                         "binaryextensions": {
@@ -15613,7 +16242,7 @@
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                       "requires": {
-                        "glob": "7.1.1"
+                        "glob": "^7.0.5"
                       },
                       "dependencies": {
                         "glob": {
@@ -15621,12 +16250,12 @@
                           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                           "requires": {
-                            "fs.realpath": "1.0.0",
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "3.0.3",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "fs.realpath": "^1.0.0",
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "^3.0.2",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "fs.realpath": {
@@ -15639,8 +16268,8 @@
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -15660,7 +16289,7 @@
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                               "requires": {
-                                "brace-expansion": "1.1.6"
+                                "brace-expansion": "^1.0.0"
                               },
                               "dependencies": {
                                 "brace-expansion": {
@@ -15668,7 +16297,7 @@
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                                   "requires": {
-                                    "balanced-match": "0.4.2",
+                                    "balanced-match": "^0.4.1",
                                     "concat-map": "0.0.1"
                                   },
                                   "dependencies": {
@@ -15691,7 +16320,7 @@
                               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -15722,10 +16351,10 @@
                   "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
                   "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
                   "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.6",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
+                    "promise-map-series": "^0.2.1",
+                    "quick-temp": "^0.1.3",
+                    "rimraf": "^2.3.4",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "quick-temp": {
@@ -15733,9 +16362,9 @@
                       "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.6.tgz",
                       "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                       "requires": {
-                        "mktemp": "0.4.0",
-                        "rimraf": "2.2.8",
-                        "underscore.string": "2.3.3"
+                        "mktemp": "~0.4.0",
+                        "rimraf": "~2.2.6",
+                        "underscore.string": "~2.3.3"
                       },
                       "dependencies": {
                         "mktemp": {
@@ -15760,7 +16389,7 @@
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                       "requires": {
-                        "glob": "7.1.1"
+                        "glob": "^7.0.5"
                       },
                       "dependencies": {
                         "glob": {
@@ -15768,12 +16397,12 @@
                           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                           "requires": {
-                            "fs.realpath": "1.0.0",
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "3.0.3",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "fs.realpath": "^1.0.0",
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "^3.0.2",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "fs.realpath": {
@@ -15786,8 +16415,8 @@
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -15807,7 +16436,7 @@
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                               "requires": {
-                                "brace-expansion": "1.1.6"
+                                "brace-expansion": "^1.0.0"
                               },
                               "dependencies": {
                                 "brace-expansion": {
@@ -15815,7 +16444,7 @@
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                                   "requires": {
-                                    "balanced-match": "0.4.2",
+                                    "balanced-match": "^0.4.1",
                                     "concat-map": "0.0.1"
                                   },
                                   "dependencies": {
@@ -15838,7 +16467,7 @@
                               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -15864,10 +16493,10 @@
                   "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.5.tgz",
                   "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
                   "requires": {
-                    "heimdalljs-logger": "0.1.7",
-                    "object-assign": "4.1.0",
-                    "path-posix": "1.0.0",
-                    "symlink-or-copy": "1.1.8"
+                    "heimdalljs-logger": "^0.1.7",
+                    "object-assign": "^4.1.0",
+                    "path-posix": "^1.0.0",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "object-assign": {
@@ -15887,7 +16516,7 @@
                   "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.3.tgz",
                   "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
                   "requires": {
-                    "rsvp": "3.2.1"
+                    "rsvp": "~3.2.1"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -15902,8 +16531,8 @@
                   "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.7.tgz",
                   "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                   "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
+                    "debug": "^2.2.0",
+                    "heimdalljs": "^0.2.0"
                   },
                   "dependencies": {
                     "debug": {
@@ -15928,7 +16557,7 @@
                   "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
                   "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
                   "requires": {
-                    "md5-o-matic": "0.1.1"
+                    "md5-o-matic": "^0.1.1"
                   },
                   "dependencies": {
                     "md5-o-matic": {
@@ -15958,7 +16587,7 @@
                   "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   }
                 },
                 "rsvp": {
@@ -15976,8 +16605,8 @@
                   "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.1.tgz",
                   "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
                   "requires": {
-                    "ensure-posix-path": "1.0.2",
-                    "matcher-collection": "1.0.4"
+                    "ensure-posix-path": "^1.0.0",
+                    "matcher-collection": "^1.0.0"
                   },
                   "dependencies": {
                     "ensure-posix-path": {
@@ -15990,7 +16619,7 @@
                       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.4.tgz",
                       "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                       "requires": {
-                        "minimatch": "3.0.3"
+                        "minimatch": "^3.0.2"
                       },
                       "dependencies": {
                         "minimatch": {
@@ -15998,7 +16627,7 @@
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -16006,7 +16635,7 @@
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -16040,8 +16669,8 @@
               "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.3.tgz",
               "integrity": "sha1-tX8YoKzlY4CVFjijs2prc9hhm4s=",
               "requires": {
-                "broccoli-kitchen-sink-helpers": "0.3.1",
-                "resolve": "1.1.7"
+                "broccoli-kitchen-sink-helpers": "^0.3.1",
+                "resolve": "^1.1.6"
               },
               "dependencies": {
                 "broccoli-kitchen-sink-helpers": {
@@ -16049,8 +16678,8 @@
                   "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
                   "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
                   "requires": {
-                    "glob": "5.0.15",
-                    "mkdirp": "0.5.1"
+                    "glob": "^5.0.10",
+                    "mkdirp": "^0.5.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -16058,11 +16687,11 @@
                       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -16070,8 +16699,8 @@
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -16091,7 +16720,7 @@
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -16099,7 +16728,7 @@
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -16122,7 +16751,7 @@
                           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -16163,7 +16792,7 @@
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
               "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
               },
               "dependencies": {
                 "jsonify": {
@@ -16180,20 +16809,20 @@
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.1.0.tgz",
           "integrity": "sha1-37kaN8kCRWRW3kpAoYgZSNZbJ9k=",
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.3.3",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "minimatch": "3.0.3",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.1"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "array-equal": {
@@ -16211,10 +16840,10 @@
               "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "promise-map-series": {
@@ -16222,7 +16851,7 @@
                   "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -16237,9 +16866,9 @@
                   "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.6.tgz",
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -16286,7 +16915,7 @@
               "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               }
             },
             "fs-tree-diff": {
@@ -16294,10 +16923,10 @@
               "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.5.tgz",
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "heimdalljs-logger": {
@@ -16305,8 +16934,8 @@
                   "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.7.tgz",
                   "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                   "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
+                    "debug": "^2.2.0",
+                    "heimdalljs": "^0.2.0"
                   }
                 },
                 "object-assign": {
@@ -16321,7 +16950,7 @@
               "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.3.tgz",
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -16336,7 +16965,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
               "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -16344,7 +16973,7 @@
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                   "requires": {
-                    "balanced-match": "0.4.2",
+                    "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -16387,7 +17016,7 @@
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -16395,12 +17024,12 @@
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -16413,8 +17042,8 @@
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -16434,7 +17063,7 @@
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -16463,8 +17092,8 @@
               "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.1.tgz",
               "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
               "requires": {
-                "ensure-posix-path": "1.0.2",
-                "matcher-collection": "1.0.4"
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
               },
               "dependencies": {
                 "ensure-posix-path": {
@@ -16477,7 +17106,7 @@
                   "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.4.tgz",
                   "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                   "requires": {
-                    "minimatch": "3.0.3"
+                    "minimatch": "^3.0.2"
                   }
                 }
               }
@@ -16494,7 +17123,7 @@
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.2.0.tgz",
           "integrity": "sha1-yqKGt30bSF310vYsZ6bxmqi1gsQ=",
           "requires": {
-            "semver": "5.3.0"
+            "semver": "^5.3.0"
           },
           "dependencies": {
             "semver": {
@@ -16517,9 +17146,9 @@
       "integrity": "sha1-8OjLfw9DweVgSU6qk3KATnoIiio=",
       "dev": true,
       "requires": {
-        "chalk": "0.5.1",
+        "chalk": "^0.5.1",
         "is-git-url": "0.2.0",
-        "semver": "4.3.6"
+        "semver": "^4.1.0"
       },
       "dependencies": {
         "chalk": {
@@ -16528,11 +17157,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -16553,7 +17182,7 @@
               "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
               "dev": true,
               "requires": {
-                "ansi-regex": "0.2.1"
+                "ansi-regex": "^0.2.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -16570,7 +17199,7 @@
               "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
               "dev": true,
               "requires": {
-                "ansi-regex": "0.2.1"
+                "ansi-regex": "^0.2.1"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -16609,11 +17238,11 @@
       "integrity": "sha1-vS6ilZNNEU08rCOTLCpE0E0ZcAI=",
       "dev": true,
       "requires": {
-        "broccoli-filter": "1.2.4",
-        "ember-cli-legacy-blueprints": "0.1.3",
-        "ember-cli-version-checker": "1.2.0",
-        "emblem": "0.8.2",
-        "lodash": "3.10.1"
+        "broccoli-filter": "^1.2.2",
+        "ember-cli-legacy-blueprints": "^0.1.1",
+        "ember-cli-version-checker": "^1.0.2",
+        "emblem": "^0.8.1",
+        "lodash": "^3.6.0"
       },
       "dependencies": {
         "broccoli-filter": {
@@ -16622,15 +17251,15 @@
           "integrity": "sha1-QJr7lLmjptqfrIE06R4gX0DMczA=",
           "dev": true,
           "requires": {
-            "broccoli-kitchen-sink-helpers": "0.3.1",
-            "broccoli-plugin": "1.3.0",
-            "copy-dereference": "1.0.0",
-            "debug": "2.3.3",
-            "mkdirp": "0.5.1",
-            "promise-map-series": "0.2.3",
-            "rsvp": "3.3.3",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.1"
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "broccoli-plugin": "^1.0.0",
+            "copy-dereference": "^1.0.0",
+            "debug": "^2.2.0",
+            "mkdirp": "^0.5.1",
+            "promise-map-series": "^0.2.1",
+            "rsvp": "^3.0.18",
+            "symlink-or-copy": "^1.0.1",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "broccoli-kitchen-sink-helpers": {
@@ -16639,8 +17268,8 @@
               "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
               "dev": true,
               "requires": {
-                "glob": "5.0.15",
-                "mkdirp": "0.5.1"
+                "glob": "^5.0.10",
+                "mkdirp": "^0.5.1"
               },
               "dependencies": {
                 "glob": {
@@ -16649,11 +17278,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -16662,8 +17291,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -16686,7 +17315,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -16695,7 +17324,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -16721,7 +17350,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -16748,10 +17377,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "quick-temp": {
@@ -16760,9 +17389,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -16791,7 +17420,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -16800,12 +17429,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -16820,8 +17449,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -16844,7 +17473,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -16853,7 +17482,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -16879,7 +17508,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -16948,7 +17577,7 @@
               "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
               "dev": true,
               "requires": {
-                "rsvp": "3.3.3"
+                "rsvp": "^3.0.14"
               }
             },
             "rsvp": {
@@ -16969,8 +17598,8 @@
               "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
               "dev": true,
               "requires": {
-                "ensure-posix-path": "1.0.2",
-                "matcher-collection": "1.0.4"
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
               },
               "dependencies": {
                 "ensure-posix-path": {
@@ -16985,7 +17614,7 @@
                   "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                   "dev": true,
                   "requires": {
-                    "minimatch": "3.0.3"
+                    "minimatch": "^3.0.2"
                   },
                   "dependencies": {
                     "minimatch": {
@@ -16994,7 +17623,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -17003,7 +17632,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -17035,23 +17664,23 @@
           "integrity": "sha1-yvR3p3UimgzWootlkwSUPbE2d3A=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "ember-cli-get-component-path-option": "1.0.0",
-            "ember-cli-get-dependency-depth": "1.0.0",
-            "ember-cli-is-package-missing": "1.0.0",
-            "ember-cli-lodash-subset": "1.0.11",
-            "ember-cli-normalize-entity-name": "1.0.0",
-            "ember-cli-path-utils": "1.0.0",
-            "ember-cli-string-utils": "1.0.0",
-            "ember-cli-test-info": "1.0.0",
-            "ember-cli-valid-component-name": "1.0.0",
-            "ember-cli-version-checker": "1.2.0",
-            "ember-router-generator": "1.2.2",
+            "chalk": "^1.1.1",
+            "ember-cli-get-component-path-option": "^1.0.0",
+            "ember-cli-get-dependency-depth": "^1.0.0",
+            "ember-cli-is-package-missing": "^1.0.0",
+            "ember-cli-lodash-subset": "^1.0.7",
+            "ember-cli-normalize-entity-name": "^1.0.0",
+            "ember-cli-path-utils": "^1.0.0",
+            "ember-cli-string-utils": "^1.0.0",
+            "ember-cli-test-info": "^1.0.0",
+            "ember-cli-valid-component-name": "^1.0.0",
+            "ember-cli-version-checker": "^1.1.7",
+            "ember-router-generator": "^1.0.0",
             "exists-sync": "0.0.3",
-            "fs-extra": "0.24.0",
-            "inflection": "1.10.0",
-            "rsvp": "3.3.3",
-            "silent-error": "1.0.1"
+            "fs-extra": "^0.24.0",
+            "inflection": "^1.7.1",
+            "rsvp": "^3.0.17",
+            "silent-error": "^1.0.0"
           },
           "dependencies": {
             "chalk": {
@@ -17060,11 +17689,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "ansi-styles": {
@@ -17085,7 +17714,7 @@
                   "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "2.0.0"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -17102,7 +17731,7 @@
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "2.0.0"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -17151,7 +17780,7 @@
               "integrity": "sha1-CxT3vLxZmqEXtf3cgeT9A8S61bc=",
               "dev": true,
               "requires": {
-                "silent-error": "1.0.1"
+                "silent-error": "^1.0.0"
               }
             },
             "ember-cli-path-utils": {
@@ -17172,7 +17801,7 @@
               "integrity": "sha1-7U6WDySel1I8+JHkrtIHLOhFd7Q=",
               "dev": true,
               "requires": {
-                "ember-cli-string-utils": "1.0.0"
+                "ember-cli-string-utils": "^1.0.0"
               }
             },
             "ember-cli-valid-component-name": {
@@ -17181,7 +17810,7 @@
               "integrity": "sha1-cVUM44fgIzBl8wswsVEKot++h+8=",
               "dev": true,
               "requires": {
-                "silent-error": "1.0.1"
+                "silent-error": "^1.0.0"
               }
             },
             "ember-router-generator": {
@@ -17190,7 +17819,7 @@
               "integrity": "sha1-YtrB9j6HNVPm1MfjLaZYnld7z2M=",
               "dev": true,
               "requires": {
-                "recast": "0.11.18"
+                "recast": "^0.11.3"
               },
               "dependencies": {
                 "recast": {
@@ -17200,9 +17829,9 @@
                   "dev": true,
                   "requires": {
                     "ast-types": "0.9.2",
-                    "esprima": "3.1.2",
-                    "private": "0.1.6",
-                    "source-map": "0.5.6"
+                    "esprima": "~3.1.0",
+                    "private": "~0.1.5",
+                    "source-map": "~0.5.0"
                   },
                   "dependencies": {
                     "ast-types": {
@@ -17245,10 +17874,10 @@
               "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "2.4.0",
-                "path-is-absolute": "1.0.1",
-                "rimraf": "2.5.4"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
               },
               "dependencies": {
                 "graceful-fs": {
@@ -17263,7 +17892,7 @@
                   "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11"
+                    "graceful-fs": "^4.1.6"
                   }
                 },
                 "path-is-absolute": {
@@ -17278,7 +17907,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -17287,12 +17916,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -17307,8 +17936,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -17331,7 +17960,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -17340,7 +17969,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -17366,7 +17995,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -17401,7 +18030,7 @@
               "integrity": "sha1-cbfVA9HG+UiCtRtWvoebETy0giw=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3"
+                "debug": "^2.2.0"
               },
               "dependencies": {
                 "debug": {
@@ -17431,7 +18060,7 @@
           "integrity": "sha1-yqKGt30bSF310vYsZ6bxmqi1gsQ=",
           "dev": true,
           "requires": {
-            "semver": "5.3.0"
+            "semver": "^5.3.0"
           },
           "dependencies": {
             "semver": {
@@ -17448,8 +18077,8 @@
           "integrity": "sha1-RNEz6DRzmIktWe9RIGQzsu+OR9U=",
           "dev": true,
           "requires": {
-            "handlebars": "2.0.0",
-            "optimist": "0.3.7"
+            "handlebars": "^2.0.0",
+            "optimist": "^0.3.7"
           },
           "dependencies": {
             "handlebars": {
@@ -17458,8 +18087,8 @@
               "integrity": "sha1-bp1/hRSjRn+l6fgswVjs/B1ax28=",
               "dev": true,
               "requires": {
-                "optimist": "0.3.7",
-                "uglify-js": "2.3.6"
+                "optimist": "~0.3",
+                "uglify-js": "~2.3"
               },
               "dependencies": {
                 "uglify-js": {
@@ -17469,9 +18098,9 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "async": "0.2.10",
-                    "optimist": "0.3.7",
-                    "source-map": "0.1.43"
+                    "async": "~0.2.6",
+                    "optimist": "~0.3.5",
+                    "source-map": "~0.1.7"
                   },
                   "dependencies": {
                     "async": {
@@ -17488,7 +18117,7 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                       },
                       "dependencies": {
                         "amdefine": {
@@ -17510,7 +18139,7 @@
               "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
               "dev": true,
               "requires": {
-                "wordwrap": "0.0.3"
+                "wordwrap": "~0.0.2"
               },
               "dependencies": {
                 "wordwrap": {
@@ -17531,14 +18160,44 @@
         }
       }
     },
+    "ember-cli-eslint": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/ember-cli-eslint/-/ember-cli-eslint-4.2.3.tgz",
+      "integrity": "sha512-1fqRz9QVLTT790Zr07aDFmAprZ1vVsaBGJOGQgDEFmBpogq8BeaQopaxogWFp748hol8nGC4QP5tbzhVD6KQHw==",
+      "dev": true,
+      "requires": {
+        "broccoli-lint-eslint": "^4.2.1",
+        "ember-cli-version-checker": "^2.1.0",
+        "rsvp": "^4.6.1",
+        "walk-sync": "^0.3.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz",
+          "integrity": "sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
+          }
+        },
+        "rsvp": {
+          "version": "4.8.3",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.3.tgz",
+          "integrity": "sha512-/OlbK31XtkPnLD2ktmZXj4g/v6q1boTDr6/3lFuDTgxVsrA3h7PH5eYyAxIvDMjRHr/DoOlzNicqDwBEo9xU7g==",
+          "dev": true
+        }
+      }
+    },
     "ember-cli-funnel": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ember-cli-funnel/-/ember-cli-funnel-0.1.2.tgz",
       "integrity": "sha1-Pw4nw2jKQsUXB1m42foIQ2lVaKY=",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "1.1.0",
-        "ember-cli-babel": "5.1.10"
+        "broccoli-funnel": "^1.0.6",
+        "ember-cli-babel": "^5.1.6"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -17547,20 +18206,20 @@
           "integrity": "sha1-37kaN8kCRWRW3kpAoYgZSNZbJ9k=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.3.3",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "minimatch": "3.0.3",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.1"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "array-equal": {
@@ -17581,10 +18240,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "promise-map-series": {
@@ -17593,7 +18252,7 @@
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -17610,9 +18269,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -17666,7 +18325,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               }
             },
             "fs-tree-diff": {
@@ -17675,10 +18334,10 @@
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "dev": true,
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "heimdalljs-logger": {
@@ -17687,8 +18346,8 @@
                   "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
+                    "debug": "^2.2.0",
+                    "heimdalljs": "^0.2.0"
                   }
                 },
                 "object-assign": {
@@ -17705,7 +18364,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -17722,7 +18381,7 @@
               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -17731,7 +18390,7 @@
                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.4.2",
+                    "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -17780,7 +18439,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -17789,12 +18448,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -17809,8 +18468,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -17833,7 +18492,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -17866,8 +18525,8 @@
               "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
               "dev": true,
               "requires": {
-                "ensure-posix-path": "1.0.2",
-                "matcher-collection": "1.0.4"
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
               },
               "dependencies": {
                 "ensure-posix-path": {
@@ -17882,7 +18541,7 @@
                   "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                   "dev": true,
                   "requires": {
-                    "minimatch": "3.0.3"
+                    "minimatch": "^3.0.2"
                   }
                 }
               }
@@ -17897,9 +18556,9 @@
       "integrity": "sha1-g7EdMHhYWVWCumHpBgIgmjfVs0g=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "5.1.10",
-        "ember-cli-version-checker": "1.2.0",
-        "rsvp": "3.3.3"
+        "ember-cli-babel": "^5.1.3",
+        "ember-cli-version-checker": "^1.1.6",
+        "rsvp": "^3.0.14"
       },
       "dependencies": {
         "ember-cli-version-checker": {
@@ -17908,7 +18567,7 @@
           "integrity": "sha1-yqKGt30bSF310vYsZ6bxmqi1gsQ=",
           "dev": true,
           "requires": {
-            "semver": "5.3.0"
+            "semver": "^5.3.0"
           },
           "dependencies": {
             "semver": {
@@ -17933,11 +18592,11 @@
       "integrity": "sha1-h3bPWXltrI8y6GJfxtHqRf+lXeE=",
       "dev": true,
       "requires": {
-        "broccoli-persistent-filter": "1.2.11",
-        "ember-cli-version-checker": "1.2.0",
-        "hash-for-dep": "1.0.3",
-        "json-stable-stringify": "1.0.1",
-        "strip-bom": "2.0.0"
+        "broccoli-persistent-filter": "^1.0.3",
+        "ember-cli-version-checker": "^1.0.2",
+        "hash-for-dep": "^1.0.2",
+        "json-stable-stringify": "^1.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "broccoli-persistent-filter": {
@@ -17946,19 +18605,19 @@
           "integrity": "sha1-lcxrCw6w3M5fjmrhj2o8xFoGv0A=",
           "dev": true,
           "requires": {
-            "async-disk-cache": "1.0.9",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "fs-tree-diff": "0.5.5",
-            "hash-for-dep": "1.0.3",
-            "heimdalljs": "0.2.3",
-            "heimdalljs-logger": "0.1.7",
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "promise-map-series": "0.2.3",
-            "rsvp": "3.3.3",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.1"
+            "async-disk-cache": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.0.0",
+            "fs-tree-diff": "^0.5.2",
+            "hash-for-dep": "^1.0.2",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "md5-hex": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "promise-map-series": "^0.2.1",
+            "rsvp": "^3.0.18",
+            "symlink-or-copy": "^1.0.1",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "async-disk-cache": {
@@ -17967,11 +18626,11 @@
               "integrity": "sha1-I7r7gjGE9GNAfkdOjV+HiZ9yymM=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3",
+                "debug": "^2.1.3",
                 "istextorbinary": "2.1.0",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.5.4",
-                "rsvp": "3.3.3"
+                "mkdirp": "^0.5.0",
+                "rimraf": "^2.5.3",
+                "rsvp": "^3.0.18"
               },
               "dependencies": {
                 "debug": {
@@ -17997,9 +18656,9 @@
                   "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
                   "dev": true,
                   "requires": {
-                    "binaryextensions": "2.0.0",
-                    "editions": "1.3.3",
-                    "textextensions": "2.0.1"
+                    "binaryextensions": "1 || 2",
+                    "editions": "^1.1.1",
+                    "textextensions": "1 || 2"
                   },
                   "dependencies": {
                     "binaryextensions": {
@@ -18028,7 +18687,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -18037,12 +18696,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -18057,8 +18716,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -18081,7 +18740,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -18090,7 +18749,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -18116,7 +18775,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -18151,10 +18810,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "quick-temp": {
@@ -18163,9 +18822,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -18194,7 +18853,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -18203,12 +18862,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -18223,8 +18882,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -18247,7 +18906,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -18256,7 +18915,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -18282,7 +18941,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -18311,10 +18970,10 @@
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "dev": true,
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "object-assign": {
@@ -18337,7 +18996,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -18354,8 +19013,8 @@
               "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3",
-                "heimdalljs": "0.2.3"
+                "debug": "^2.2.0",
+                "heimdalljs": "^0.2.0"
               },
               "dependencies": {
                 "debug": {
@@ -18383,7 +19042,7 @@
               "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
               "dev": true,
               "requires": {
-                "md5-o-matic": "0.1.1"
+                "md5-o-matic": "^0.1.1"
               },
               "dependencies": {
                 "md5-o-matic": {
@@ -18417,7 +19076,7 @@
               "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
               "dev": true,
               "requires": {
-                "rsvp": "3.3.3"
+                "rsvp": "^3.0.14"
               }
             },
             "rsvp": {
@@ -18438,8 +19097,8 @@
               "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
               "dev": true,
               "requires": {
-                "ensure-posix-path": "1.0.2",
-                "matcher-collection": "1.0.4"
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
               },
               "dependencies": {
                 "ensure-posix-path": {
@@ -18454,7 +19113,7 @@
                   "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                   "dev": true,
                   "requires": {
-                    "minimatch": "3.0.3"
+                    "minimatch": "^3.0.2"
                   },
                   "dependencies": {
                     "minimatch": {
@@ -18463,7 +19122,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -18472,7 +19131,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -18504,7 +19163,7 @@
           "integrity": "sha1-yqKGt30bSF310vYsZ6bxmqi1gsQ=",
           "dev": true,
           "requires": {
-            "semver": "5.3.0"
+            "semver": "^5.3.0"
           },
           "dependencies": {
             "semver": {
@@ -18521,8 +19180,8 @@
           "integrity": "sha1-tX8YoKzlY4CVFjijs2prc9hhm4s=",
           "dev": true,
           "requires": {
-            "broccoli-kitchen-sink-helpers": "0.3.1",
-            "resolve": "1.1.7"
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "resolve": "^1.1.6"
           },
           "dependencies": {
             "broccoli-kitchen-sink-helpers": {
@@ -18531,8 +19190,8 @@
               "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
               "dev": true,
               "requires": {
-                "glob": "5.0.15",
-                "mkdirp": "0.5.1"
+                "glob": "^5.0.10",
+                "mkdirp": "^0.5.1"
               },
               "dependencies": {
                 "glob": {
@@ -18541,11 +19200,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -18554,8 +19213,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -18578,7 +19237,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -18587,7 +19246,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -18613,7 +19272,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -18665,7 +19324,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           },
           "dependencies": {
             "jsonify": {
@@ -18682,7 +19341,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           },
           "dependencies": {
             "is-utf8": {
@@ -18701,10 +19360,10 @@
       "integrity": "sha1-QJX+Qj+TECckwHJeTdGjHyXiTeU=",
       "dev": true,
       "requires": {
-        "babel-plugin-htmlbars-inline-precompile": "0.1.0",
-        "ember-cli-babel": "5.1.10",
-        "ember-cli-htmlbars": "1.1.1",
-        "hash-for-dep": "1.0.3"
+        "babel-plugin-htmlbars-inline-precompile": "^0.1.0",
+        "ember-cli-babel": "^5.1.3",
+        "ember-cli-htmlbars": "^1.0.0",
+        "hash-for-dep": "^1.0.2"
       },
       "dependencies": {
         "babel-plugin-htmlbars-inline-precompile": {
@@ -18719,8 +19378,8 @@
           "integrity": "sha1-tX8YoKzlY4CVFjijs2prc9hhm4s=",
           "dev": true,
           "requires": {
-            "broccoli-kitchen-sink-helpers": "0.3.1",
-            "resolve": "1.1.7"
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "resolve": "^1.1.6"
           },
           "dependencies": {
             "broccoli-kitchen-sink-helpers": {
@@ -18729,8 +19388,8 @@
               "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
               "dev": true,
               "requires": {
-                "glob": "5.0.15",
-                "mkdirp": "0.5.1"
+                "glob": "^5.0.10",
+                "mkdirp": "^0.5.1"
               },
               "dependencies": {
                 "glob": {
@@ -18739,11 +19398,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -18752,8 +19411,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -18776,7 +19435,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -18785,7 +19444,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -18811,7 +19470,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -18865,1186 +19524,16 @@
       "integrity": "sha1-3a25o0bF7WlOwPnhH0mZTqyv0nc=",
       "dev": true
     },
-    "ember-cli-jshint": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/ember-cli-jshint/-/ember-cli-jshint-1.0.5.tgz",
-      "integrity": "sha1-igGF8Zy9cTaZXuaskpQaVg4mW5E=",
-      "dev": true,
-      "requires": {
-        "broccoli-jshint": "1.2.0"
-      },
-      "dependencies": {
-        "broccoli-jshint": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/broccoli-jshint/-/broccoli-jshint-1.2.0.tgz",
-          "integrity": "sha1-jNVl0RoEv9MsuPhaD37eHlvnpqI=",
-          "dev": true,
-          "requires": {
-            "broccoli-persistent-filter": "1.2.11",
-            "chalk": "0.4.0",
-            "findup-sync": "0.3.0",
-            "jshint": "2.9.4",
-            "json-stable-stringify": "1.0.1",
-            "mkdirp": "0.4.2"
-          },
-          "dependencies": {
-            "broccoli-persistent-filter": {
-              "version": "1.2.11",
-              "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.11.tgz",
-              "integrity": "sha1-lcxrCw6w3M5fjmrhj2o8xFoGv0A=",
-              "dev": true,
-              "requires": {
-                "async-disk-cache": "1.0.9",
-                "blank-object": "1.0.2",
-                "broccoli-plugin": "1.3.0",
-                "fs-tree-diff": "0.5.5",
-                "hash-for-dep": "1.0.3",
-                "heimdalljs": "0.2.3",
-                "heimdalljs-logger": "0.1.7",
-                "md5-hex": "1.3.0",
-                "mkdirp": "0.5.1",
-                "promise-map-series": "0.2.3",
-                "rsvp": "3.3.3",
-                "symlink-or-copy": "1.1.8",
-                "walk-sync": "0.3.1"
-              },
-              "dependencies": {
-                "async-disk-cache": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.9.tgz",
-                  "integrity": "sha1-I7r7gjGE9GNAfkdOjV+HiZ9yymM=",
-                  "dev": true,
-                  "requires": {
-                    "debug": "2.3.3",
-                    "istextorbinary": "2.1.0",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.5.4",
-                    "rsvp": "3.3.3"
-                  },
-                  "dependencies": {
-                    "debug": {
-                      "version": "2.3.3",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-                      "dev": true,
-                      "requires": {
-                        "ms": "0.7.2"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.2",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "istextorbinary": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-                      "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
-                      "dev": true,
-                      "requires": {
-                        "binaryextensions": "2.0.0",
-                        "editions": "1.3.3",
-                        "textextensions": "2.0.1"
-                      },
-                      "dependencies": {
-                        "binaryextensions": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.0.0.tgz",
-                          "integrity": "sha1-5ZfRp6ajVYotHHJBoWyZll5qpA8=",
-                          "dev": true
-                        },
-                        "editions": {
-                          "version": "1.3.3",
-                          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
-                          "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls=",
-                          "dev": true
-                        },
-                        "textextensions": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.0.1.tgz",
-                          "integrity": "sha1-vozyLWU3nBUTGfiPAzWtj2Z6vco=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.5.4",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                      "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-                      "dev": true,
-                      "requires": {
-                        "glob": "7.1.1"
-                      },
-                      "dependencies": {
-                        "glob": {
-                          "version": "7.1.1",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-                          "dev": true,
-                          "requires": {
-                            "fs.realpath": "1.0.0",
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "3.0.3",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
-                          },
-                          "dependencies": {
-                            "fs.realpath": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                              "dev": true
-                            },
-                            "inflight": {
-                              "version": "1.0.6",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                              "dev": true,
-                              "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
-                              },
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.3",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                              "dev": true
-                            },
-                            "minimatch": {
-                              "version": "3.0.3",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                              "dev": true,
-                              "requires": {
-                                "brace-expansion": "1.1.6"
-                              },
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.6",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                                  "dev": true,
-                                  "requires": {
-                                    "balanced-match": "0.4.2",
-                                    "concat-map": "0.0.1"
-                                  },
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.4.2",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                                      "dev": true
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                                      "dev": true
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.4.0",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                              "dev": true,
-                              "requires": {
-                                "wrappy": "1.0.2"
-                              },
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "path-is-absolute": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "blank-object": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
-                  "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk=",
-                  "dev": true
-                },
-                "broccoli-plugin": {
-                  "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
-                  "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
-                  "dev": true,
-                  "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.6",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
-                  },
-                  "dependencies": {
-                    "quick-temp": {
-                      "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.6.tgz",
-                      "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
-                      "dev": true,
-                      "requires": {
-                        "mktemp": "0.4.0",
-                        "rimraf": "2.2.8",
-                        "underscore.string": "2.3.3"
-                      },
-                      "dependencies": {
-                        "mktemp": {
-                          "version": "0.4.0",
-                          "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
-                          "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws=",
-                          "dev": true
-                        },
-                        "rimraf": {
-                          "version": "2.2.8",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-                          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-                          "dev": true
-                        },
-                        "underscore.string": {
-                          "version": "2.3.3",
-                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-                          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.5.4",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                      "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-                      "dev": true,
-                      "requires": {
-                        "glob": "7.1.1"
-                      },
-                      "dependencies": {
-                        "glob": {
-                          "version": "7.1.1",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-                          "dev": true,
-                          "requires": {
-                            "fs.realpath": "1.0.0",
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "3.0.3",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
-                          },
-                          "dependencies": {
-                            "fs.realpath": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                              "dev": true
-                            },
-                            "inflight": {
-                              "version": "1.0.6",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                              "dev": true,
-                              "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
-                              },
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.3",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                              "dev": true
-                            },
-                            "minimatch": {
-                              "version": "3.0.3",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                              "dev": true,
-                              "requires": {
-                                "brace-expansion": "1.1.6"
-                              },
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.6",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                                  "dev": true,
-                                  "requires": {
-                                    "balanced-match": "0.4.2",
-                                    "concat-map": "0.0.1"
-                                  },
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.4.2",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                                      "dev": true
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                                      "dev": true
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.4.0",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                              "dev": true,
-                              "requires": {
-                                "wrappy": "1.0.2"
-                              },
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "path-is-absolute": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "fs-tree-diff": {
-                  "version": "0.5.5",
-                  "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.5.tgz",
-                  "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
-                  "dev": true,
-                  "requires": {
-                    "heimdalljs-logger": "0.1.7",
-                    "object-assign": "4.1.0",
-                    "path-posix": "1.0.0",
-                    "symlink-or-copy": "1.1.8"
-                  },
-                  "dependencies": {
-                    "object-assign": {
-                      "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-                      "dev": true
-                    },
-                    "path-posix": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-                      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "hash-for-dep": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.3.tgz",
-                  "integrity": "sha1-tX8YoKzlY4CVFjijs2prc9hhm4s=",
-                  "dev": true,
-                  "requires": {
-                    "broccoli-kitchen-sink-helpers": "0.3.1",
-                    "resolve": "1.1.7"
-                  },
-                  "dependencies": {
-                    "broccoli-kitchen-sink-helpers": {
-                      "version": "0.3.1",
-                      "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
-                      "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
-                      "dev": true,
-                      "requires": {
-                        "glob": "5.0.15",
-                        "mkdirp": "0.5.1"
-                      },
-                      "dependencies": {
-                        "glob": {
-                          "version": "5.0.15",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                          "dev": true,
-                          "requires": {
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "3.0.3",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
-                          },
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.6",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                              "dev": true,
-                              "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
-                              },
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.3",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                              "dev": true
-                            },
-                            "minimatch": {
-                              "version": "3.0.3",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                              "dev": true,
-                              "requires": {
-                                "brace-expansion": "1.1.6"
-                              },
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.6",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                                  "dev": true,
-                                  "requires": {
-                                    "balanced-match": "0.4.2",
-                                    "concat-map": "0.0.1"
-                                  },
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.4.2",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                                      "dev": true
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                                      "dev": true
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.4.0",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                              "dev": true,
-                              "requires": {
-                                "wrappy": "1.0.2"
-                              },
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "path-is-absolute": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "resolve": {
-                      "version": "1.1.7",
-                      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-                      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-                      "dev": true
-                    }
-                  }
-                },
-                "heimdalljs": {
-                  "version": "0.2.3",
-                  "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.3.tgz",
-                  "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
-                  "dev": true,
-                  "requires": {
-                    "rsvp": "3.2.1"
-                  },
-                  "dependencies": {
-                    "rsvp": {
-                      "version": "3.2.1",
-                      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-                      "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
-                      "dev": true
-                    }
-                  }
-                },
-                "heimdalljs-logger": {
-                  "version": "0.1.7",
-                  "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.7.tgz",
-                  "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
-                  "dev": true,
-                  "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
-                  },
-                  "dependencies": {
-                    "debug": {
-                      "version": "2.3.3",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-                      "dev": true,
-                      "requires": {
-                        "ms": "0.7.2"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.2",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "md5-hex": {
-                  "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-                  "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-                  "dev": true,
-                  "requires": {
-                    "md5-o-matic": "0.1.1"
-                  },
-                  "dependencies": {
-                    "md5-o-matic": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-                      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-                      "dev": true
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                  "dev": true,
-                  "requires": {
-                    "minimist": "0.0.8"
-                  },
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                      "dev": true
-                    }
-                  }
-                },
-                "promise-map-series": {
-                  "version": "0.2.3",
-                  "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
-                  "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
-                  "dev": true,
-                  "requires": {
-                    "rsvp": "3.3.3"
-                  }
-                },
-                "rsvp": {
-                  "version": "3.3.3",
-                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.3.3.tgz",
-                  "integrity": "sha1-NGM8qvi8Zs7/S+PC4d/9AyU4qBM=",
-                  "dev": true
-                },
-                "symlink-or-copy": {
-                  "version": "1.1.8",
-                  "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz",
-                  "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM=",
-                  "dev": true
-                },
-                "walk-sync": {
-                  "version": "0.3.1",
-                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.1.tgz",
-                  "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
-                  "dev": true,
-                  "requires": {
-                    "ensure-posix-path": "1.0.2",
-                    "matcher-collection": "1.0.4"
-                  },
-                  "dependencies": {
-                    "ensure-posix-path": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
-                      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI=",
-                      "dev": true
-                    },
-                    "matcher-collection": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.4.tgz",
-                      "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
-                      "dev": true,
-                      "requires": {
-                        "minimatch": "3.0.3"
-                      },
-                      "dependencies": {
-                        "minimatch": {
-                          "version": "3.0.3",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                          "dev": true,
-                          "requires": {
-                            "brace-expansion": "1.1.6"
-                          },
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.6",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                              "dev": true,
-                              "requires": {
-                                "balanced-match": "0.4.2",
-                                "concat-map": "0.0.1"
-                              },
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.4.2",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                                  "dev": true
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "chalk": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-              "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "1.0.0",
-                "has-color": "0.1.7",
-                "strip-ansi": "0.1.1"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-                  "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-                  "dev": true
-                },
-                "has-color": {
-                  "version": "0.1.7",
-                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-                  "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-                  "dev": true
-                },
-                "strip-ansi": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-                  "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-                  "dev": true
-                }
-              }
-            },
-            "findup-sync": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-              "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
-              "dev": true,
-              "requires": {
-                "glob": "5.0.15"
-              },
-              "dependencies": {
-                "glob": {
-                  "version": "5.0.15",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                  "dev": true,
-                  "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
-                  },
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                      "dev": true,
-                      "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                      "dev": true
-                    },
-                    "minimatch": {
-                      "version": "3.0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                      "dev": true,
-                      "requires": {
-                        "brace-expansion": "1.1.6"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.6",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                          "dev": true,
-                          "requires": {
-                            "balanced-match": "0.4.2",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.4.2",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                              "dev": true
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                      "dev": true,
-                      "requires": {
-                        "wrappy": "1.0.2"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "jshint": {
-              "version": "2.9.4",
-              "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.4.tgz",
-              "integrity": "sha1-XjupeEjVKQJz21FK7kf+JM9ZKTQ=",
-              "dev": true,
-              "requires": {
-                "cli": "1.0.1",
-                "console-browserify": "1.1.0",
-                "exit": "0.1.2",
-                "htmlparser2": "3.8.3",
-                "lodash": "3.7.0",
-                "minimatch": "3.0.3",
-                "shelljs": "0.3.0",
-                "strip-json-comments": "1.0.4"
-              },
-              "dependencies": {
-                "cli": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
-                  "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
-                  "dev": true,
-                  "requires": {
-                    "exit": "0.1.2",
-                    "glob": "7.1.1"
-                  },
-                  "dependencies": {
-                    "glob": {
-                      "version": "7.1.1",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-                      "dev": true,
-                      "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                      },
-                      "dependencies": {
-                        "fs.realpath": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                          "dev": true
-                        },
-                        "inflight": {
-                          "version": "1.0.6",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                          "dev": true,
-                          "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
-                          },
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                          "dev": true
-                        },
-                        "once": {
-                          "version": "1.4.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                          "dev": true,
-                          "requires": {
-                            "wrappy": "1.0.2"
-                          },
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "console-browserify": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-                  "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-                  "dev": true,
-                  "requires": {
-                    "date-now": "0.1.4"
-                  },
-                  "dependencies": {
-                    "date-now": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-                      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-                      "dev": true
-                    }
-                  }
-                },
-                "exit": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-                  "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-                  "dev": true
-                },
-                "htmlparser2": {
-                  "version": "3.8.3",
-                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-                  "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-                  "dev": true,
-                  "requires": {
-                    "domelementtype": "1.3.0",
-                    "domhandler": "2.3.0",
-                    "domutils": "1.5.1",
-                    "entities": "1.0.0",
-                    "readable-stream": "1.1.14"
-                  },
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.3.0",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-                      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-                      "dev": true
-                    },
-                    "domhandler": {
-                      "version": "2.3.0",
-                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-                      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-                      "dev": true,
-                      "requires": {
-                        "domelementtype": "1.3.0"
-                      }
-                    },
-                    "domutils": {
-                      "version": "1.5.1",
-                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-                      "dev": true,
-                      "requires": {
-                        "dom-serializer": "0.1.0",
-                        "domelementtype": "1.3.0"
-                      },
-                      "dependencies": {
-                        "dom-serializer": {
-                          "version": "0.1.0",
-                          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                          "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-                          "dev": true,
-                          "requires": {
-                            "domelementtype": "1.1.3",
-                            "entities": "1.1.1"
-                          },
-                          "dependencies": {
-                            "domelementtype": {
-                              "version": "1.1.3",
-                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-                              "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-                              "dev": true
-                            },
-                            "entities": {
-                              "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-                              "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "entities": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-                      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
-                      "dev": true
-                    },
-                    "readable-stream": {
-                      "version": "1.1.14",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                      "dev": true,
-                      "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                          "dev": true
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                          "dev": true
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                          "dev": true
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "3.7.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
-                  "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
-                  "dev": true
-                },
-                "minimatch": {
-                  "version": "3.0.3",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "1.1.6"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                      "dev": true,
-                      "requires": {
-                        "balanced-match": "0.4.2",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.2",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                          "dev": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "shelljs": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-                  "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
-                  "dev": true
-                },
-                "strip-json-comments": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                  "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-                  "dev": true
-                }
-              }
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-              "dev": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              },
-              "dependencies": {
-                "jsonify": {
-                  "version": "0.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-                  "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-                  "dev": true
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.4.2",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.4.2.tgz",
-              "integrity": "sha1-QnyMGOzjmLky9vZm9OHlt3QOeMg=",
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "ember-cli-less": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/ember-cli-less/-/ember-cli-less-1.5.3.tgz",
       "integrity": "sha1-9I2MlnqSueohqv3Pns4NtIOWOdM=",
       "dev": true,
       "requires": {
-        "broccoli-less-single": "0.6.3",
-        "broccoli-merge-trees": "1.2.1",
-        "ember-cli-version-checker": "1.2.0",
-        "lodash.merge": "3.3.2"
+        "broccoli-less-single": "^0.6.0",
+        "broccoli-merge-trees": "^1.0.0",
+        "ember-cli-version-checker": "^1.1.4",
+        "lodash.merge": "^3.3.2"
       },
       "dependencies": {
         "broccoli-less-single": {
@@ -20053,11 +19542,11 @@
           "integrity": "sha1-4luumwJ2lHT262a4tHMAFpBrjB8=",
           "dev": true,
           "requires": {
-            "broccoli-caching-writer": "2.3.1",
-            "include-path-searcher": "0.1.0",
-            "less": "2.7.1",
-            "lodash.merge": "3.3.2",
-            "mkdirp": "0.5.1"
+            "broccoli-caching-writer": "^2.1.0",
+            "include-path-searcher": "^0.1.0",
+            "less": "^2.5.0",
+            "lodash.merge": "^3.3.2",
+            "mkdirp": "^0.5.0"
           },
           "dependencies": {
             "broccoli-caching-writer": {
@@ -20066,12 +19555,12 @@
               "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
               "dev": true,
               "requires": {
-                "broccoli-kitchen-sink-helpers": "0.2.9",
+                "broccoli-kitchen-sink-helpers": "^0.2.5",
                 "broccoli-plugin": "1.1.0",
-                "debug": "2.3.3",
-                "rimraf": "2.5.4",
-                "rsvp": "3.3.3",
-                "walk-sync": "0.2.7"
+                "debug": "^2.1.1",
+                "rimraf": "^2.2.8",
+                "rsvp": "^3.0.17",
+                "walk-sync": "^0.2.5"
               },
               "dependencies": {
                 "broccoli-kitchen-sink-helpers": {
@@ -20080,8 +19569,8 @@
                   "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
                   "dev": true,
                   "requires": {
-                    "glob": "5.0.15",
-                    "mkdirp": "0.5.1"
+                    "glob": "^5.0.10",
+                    "mkdirp": "^0.5.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -20090,11 +19579,11 @@
                       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                       "dev": true,
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -20103,8 +19592,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -20127,7 +19616,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -20136,7 +19625,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -20162,7 +19651,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -20189,10 +19678,10 @@
                   "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
                   "dev": true,
                   "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.6",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
+                    "promise-map-series": "^0.2.1",
+                    "quick-temp": "^0.1.3",
+                    "rimraf": "^2.3.4",
+                    "symlink-or-copy": "^1.0.1"
                   },
                   "dependencies": {
                     "promise-map-series": {
@@ -20201,7 +19690,7 @@
                       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                       "dev": true,
                       "requires": {
-                        "rsvp": "3.3.3"
+                        "rsvp": "^3.0.14"
                       }
                     },
                     "quick-temp": {
@@ -20210,9 +19699,9 @@
                       "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                       "dev": true,
                       "requires": {
-                        "mktemp": "0.4.0",
-                        "rimraf": "2.2.8",
-                        "underscore.string": "2.3.3"
+                        "mktemp": "~0.4.0",
+                        "rimraf": "~2.2.6",
+                        "underscore.string": "~2.3.3"
                       },
                       "dependencies": {
                         "mktemp": {
@@ -20266,7 +19755,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -20275,12 +19764,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -20295,8 +19784,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -20319,7 +19808,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -20328,7 +19817,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -20354,7 +19843,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -20387,8 +19876,8 @@
                   "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
                   "dev": true,
                   "requires": {
-                    "ensure-posix-path": "1.0.2",
-                    "matcher-collection": "1.0.4"
+                    "ensure-posix-path": "^1.0.0",
+                    "matcher-collection": "^1.0.0"
                   },
                   "dependencies": {
                     "ensure-posix-path": {
@@ -20403,7 +19892,7 @@
                       "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                       "dev": true,
                       "requires": {
-                        "minimatch": "3.0.3"
+                        "minimatch": "^3.0.2"
                       },
                       "dependencies": {
                         "minimatch": {
@@ -20412,7 +19901,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -20421,7 +19910,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -20459,13 +19948,13 @@
               "integrity": "sha1-bL/qIrO4MDBOml+zcdVPpIDJ188=",
               "dev": true,
               "requires": {
-                "errno": "0.1.4",
-                "graceful-fs": "4.1.11",
-                "image-size": "0.5.0",
-                "mime": "1.3.4",
-                "mkdirp": "0.5.1",
-                "promise": "7.1.1",
-                "source-map": "0.5.6"
+                "errno": "^0.1.1",
+                "graceful-fs": "^4.1.2",
+                "image-size": "~0.5.0",
+                "mime": "^1.2.11",
+                "mkdirp": "^0.5.0",
+                "promise": "^7.1.1",
+                "source-map": "^0.5.3"
               },
               "dependencies": {
                 "errno": {
@@ -20475,7 +19964,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "prr": "0.0.0"
+                    "prr": "~0.0.0"
                   },
                   "dependencies": {
                     "prr": {
@@ -20515,7 +20004,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "asap": "2.0.5"
+                    "asap": "~2.0.3"
                   },
                   "dependencies": {
                     "asap": {
@@ -20561,14 +20050,14 @@
           "integrity": "sha1-FqdJTtVtvmFhH2wtSBfPuq0qMFU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "heimdalljs-logger": "0.1.7",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           },
           "dependencies": {
             "broccoli-plugin": {
@@ -20577,10 +20066,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "promise-map-series": {
@@ -20589,7 +20078,7 @@
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -20606,9 +20095,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -20648,7 +20137,7 @@
                   "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
                   "dev": true,
                   "requires": {
-                    "os-tmpdir": "1.0.2"
+                    "os-tmpdir": "~1.0.1"
                   },
                   "dependencies": {
                     "os-tmpdir": {
@@ -20667,7 +20156,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               },
               "dependencies": {
                 "blank-object": {
@@ -20684,10 +20173,10 @@
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "dev": true,
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "object-assign": {
@@ -20710,7 +20199,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -20727,8 +20216,8 @@
               "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3",
-                "heimdalljs": "0.2.3"
+                "debug": "^2.2.0",
+                "heimdalljs": "^0.2.0"
               },
               "dependencies": {
                 "debug": {
@@ -20756,7 +20245,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -20765,12 +20254,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -20785,8 +20274,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -20809,7 +20298,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -20818,7 +20307,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -20844,7 +20333,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -20879,7 +20368,7 @@
           "integrity": "sha1-yqKGt30bSF310vYsZ6bxmqi1gsQ=",
           "dev": true,
           "requires": {
-            "semver": "5.3.0"
+            "semver": "^5.3.0"
           },
           "dependencies": {
             "semver": {
@@ -20896,17 +20385,17 @@
           "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
           "dev": true,
           "requires": {
-            "lodash._arraycopy": "3.0.0",
-            "lodash._arrayeach": "3.0.0",
-            "lodash._createassigner": "3.1.1",
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4",
-            "lodash.isplainobject": "3.2.0",
-            "lodash.istypedarray": "3.0.6",
-            "lodash.keys": "3.1.2",
-            "lodash.keysin": "3.0.8",
-            "lodash.toplainobject": "3.0.0"
+            "lodash._arraycopy": "^3.0.0",
+            "lodash._arrayeach": "^3.0.0",
+            "lodash._createassigner": "^3.0.0",
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.isplainobject": "^3.0.0",
+            "lodash.istypedarray": "^3.0.0",
+            "lodash.keys": "^3.0.0",
+            "lodash.keysin": "^3.0.0",
+            "lodash.toplainobject": "^3.0.0"
           },
           "dependencies": {
             "lodash._arraycopy": {
@@ -20927,9 +20416,9 @@
               "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
               "dev": true,
               "requires": {
-                "lodash._bindcallback": "3.0.1",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash.restparam": "3.6.1"
+                "lodash._bindcallback": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash.restparam": "^3.0.0"
               },
               "dependencies": {
                 "lodash._bindcallback": {
@@ -20976,9 +20465,9 @@
               "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
               "dev": true,
               "requires": {
-                "lodash._basefor": "3.0.3",
-                "lodash.isarguments": "3.1.0",
-                "lodash.keysin": "3.0.8"
+                "lodash._basefor": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.keysin": "^3.0.0"
               },
               "dependencies": {
                 "lodash._basefor": {
@@ -21001,9 +20490,9 @@
               "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
               "dev": true,
               "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
               }
             },
             "lodash.keysin": {
@@ -21012,8 +20501,8 @@
               "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
               "dev": true,
               "requires": {
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
               }
             },
             "lodash.toplainobject": {
@@ -21022,8 +20511,8 @@
               "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
               "dev": true,
               "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash.keysin": "3.0.8"
+                "lodash._basecopy": "^3.0.0",
+                "lodash.keysin": "^3.0.0"
               },
               "dependencies": {
                 "lodash._basecopy": {
@@ -21042,51 +20531,96 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/ember-cli-mirage/-/ember-cli-mirage-0.3.4.tgz",
       "integrity": "sha1-7rnW4CwMScgZFXYheLq5pC2Grag=",
+      "dev": true,
       "requires": {
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-stew": "1.5.0",
-        "chalk": "1.1.3",
-        "ember-cli-babel": "5.1.10",
-        "ember-cli-node-assets": "0.1.6",
+        "broccoli-funnel": "^1.0.2",
+        "broccoli-merge-trees": "^1.1.0",
+        "broccoli-stew": "^1.5.0",
+        "chalk": "^1.1.1",
+        "ember-cli-babel": "^5.1.7",
+        "ember-cli-node-assets": "^0.1.4",
         "ember-get-config": "0.2.1",
-        "ember-inflector": "2.0.1",
-        "ember-lodash": "4.17.5",
-        "exists-sync": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
-        "fake-xml-http-request": "1.6.0",
-        "faker": "3.1.0",
-        "pretender": "1.6.0",
-        "route-recognizer": "0.2.10"
+        "ember-inflector": "^2.0.0",
+        "ember-lodash": "^4.17.3",
+        "exists-sync": "0.0.3",
+        "fake-xml-http-request": "^1.4.0",
+        "faker": "^3.0.0",
+        "pretender": "^1.4.2",
+        "route-recognizer": "^0.2.3"
       },
       "dependencies": {
-        "ember-inflector": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/ember-inflector/-/ember-inflector-2.0.1.tgz",
-          "integrity": "sha512-CFiWADOwuyRJwlOm2/8qvCRPLPylowvew+2vgFUFjd6UDvunwQfOJ/LS06PqnNcTfKN5Wu3Rcvj81NzIVkJmSg==",
+        "broccoli-debug": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
+          "integrity": "sha512-CixMUndBqTljCc26i6ubhBrGbAWXpWBsGJFce6ZOr76Tul2Ev1xxM0tmf7OjSzdYhkr5BrPd/CNbR9VMPi+NBg==",
+          "dev": true,
           "requires": {
-            "ember-cli-babel": "6.8.2"
+            "broccoli-plugin": "^1.2.1",
+            "fs-tree-diff": "^0.5.2",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "symlink-or-copy": "^1.1.8",
+            "tree-sync": "^1.2.2"
+          }
+        },
+        "ember-inflector": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/ember-inflector/-/ember-inflector-2.3.0.tgz",
+          "integrity": "sha1-lHl+ug7qmNkCqh5doPCu72BTMX8=",
+          "dev": true,
+          "requires": {
+            "ember-cli-babel": "^6.0.0"
           },
           "dependencies": {
-            "ember-cli-babel": {
-              "version": "6.8.2",
-              "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz",
-              "integrity": "sha1-6sJ4WWT0dD9MgVzVPGKI8AzAh9c=",
+            "broccoli-funnel": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+              "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+              "dev": true,
               "requires": {
-                "amd-name-resolver": "0.0.7",
-                "babel-plugin-debug-macros": "0.1.11",
-                "babel-plugin-ember-modules-api-polyfill": "2.0.1",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-polyfill": "6.26.0",
-                "babel-preset-env": "1.6.0",
-                "broccoli-babel-transpiler": "6.1.2",
-                "broccoli-debug": "0.6.3",
-                "broccoli-funnel": "1.2.0",
-                "broccoli-source": "1.1.0",
-                "clone": "2.1.1",
-                "ember-cli-version-checker": "2.0.0"
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            },
+            "ember-cli-babel": {
+              "version": "6.16.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.16.0.tgz",
+              "integrity": "sha512-rzWkVdKVk2KSbQ81TxmLli+LWdBEqF+FHE83rUQXVOV4FguJDtP1w2AW08f8QjuztbnQ5+VUGCb7H0dL8UwOVw==",
+              "dev": true,
+              "requires": {
+                "amd-name-resolver": "1.2.0",
+                "babel-plugin-debug-macros": "^0.2.0-beta.6",
+                "babel-plugin-ember-modules-api-polyfill": "^2.3.2",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+                "babel-polyfill": "^6.26.0",
+                "babel-preset-env": "^1.7.0",
+                "broccoli-babel-transpiler": "^6.4.5",
+                "broccoli-debug": "^0.6.4",
+                "broccoli-funnel": "^2.0.0",
+                "broccoli-source": "^1.1.0",
+                "clone": "^2.0.0",
+                "ember-cli-version-checker": "^2.1.2",
+                "semver": "^5.5.0"
               }
             }
           }
+        },
+        "semver": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+          "dev": true
         }
       }
     },
@@ -21094,13 +20628,14 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ember-cli-node-assets/-/ember-cli-node-assets-0.1.6.tgz",
       "integrity": "sha1-ZIiilJBIyAGtbZ4zdTx7zjL8EUY=",
+      "dev": true,
       "requires": {
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-unwatched-tree": "0.1.3",
-        "debug": "2.6.8",
-        "lodash": "4.17.4",
-        "resolve": "1.4.0"
+        "broccoli-funnel": "^1.0.1",
+        "broccoli-merge-trees": "^1.1.1",
+        "broccoli-unwatched-tree": "^0.1.1",
+        "debug": "^2.2.0",
+        "lodash": "^4.5.1",
+        "resolve": "^1.1.7"
       }
     },
     "ember-cli-qunit": {
@@ -21109,17 +20644,17 @@
       "integrity": "sha1-tzuzbCiHJh7DgTfORpSt2WiIkew=",
       "dev": true,
       "requires": {
-        "broccoli-babel-transpiler": "5.6.1",
-        "broccoli-concat": "2.3.8",
-        "broccoli-funnel": "1.1.0",
-        "broccoli-merge-trees": "1.2.1",
-        "ember-cli-babel": "5.1.10",
-        "ember-cli-version-checker": "1.2.0",
-        "ember-qunit": "0.4.22",
-        "qunit-notifications": "0.1.1",
-        "qunitjs": "1.23.1",
-        "resolve": "1.1.7",
-        "rsvp": "3.3.3"
+        "broccoli-babel-transpiler": "^5.5.0",
+        "broccoli-concat": "^2.2.0",
+        "broccoli-funnel": "^1.0.1",
+        "broccoli-merge-trees": "^1.1.0",
+        "ember-cli-babel": "^5.1.5",
+        "ember-cli-version-checker": "^1.1.4",
+        "ember-qunit": "^0.4.18",
+        "qunit-notifications": "^0.1.1",
+        "qunitjs": "^1.20.0",
+        "resolve": "^1.1.6",
+        "rsvp": "^3.2.1"
       },
       "dependencies": {
         "broccoli-babel-transpiler": {
@@ -21128,13 +20663,13 @@
           "integrity": "sha1-lxhNyxQLQKpX8/84Mwr8zGddCjw=",
           "dev": true,
           "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.1.0",
-            "broccoli-merge-trees": "1.2.1",
-            "broccoli-persistent-filter": "1.2.11",
-            "clone": "0.2.0",
-            "hash-for-dep": "1.0.3",
-            "json-stable-stringify": "1.0.1"
+            "babel-core": "^5.0.0",
+            "broccoli-funnel": "^1.0.0",
+            "broccoli-merge-trees": "^1.0.0",
+            "broccoli-persistent-filter": "^1.0.1",
+            "clone": "^0.2.0",
+            "hash-for-dep": "^1.0.2",
+            "json-stable-stringify": "^1.0.0"
           },
           "dependencies": {
             "babel-core": {
@@ -21143,52 +20678,52 @@
               "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
               "dev": true,
               "requires": {
-                "babel-plugin-constant-folding": "1.0.1",
-                "babel-plugin-dead-code-elimination": "1.0.2",
-                "babel-plugin-eval": "1.0.1",
-                "babel-plugin-inline-environment-variables": "1.0.1",
-                "babel-plugin-jscript": "1.0.4",
-                "babel-plugin-member-expression-literals": "1.0.1",
-                "babel-plugin-property-literals": "1.0.1",
-                "babel-plugin-proto-to-assign": "1.0.4",
-                "babel-plugin-react-constant-elements": "1.0.3",
-                "babel-plugin-react-display-name": "1.0.3",
-                "babel-plugin-remove-console": "1.0.1",
-                "babel-plugin-remove-debugger": "1.0.1",
-                "babel-plugin-runtime": "1.0.7",
-                "babel-plugin-undeclared-variables-check": "1.0.2",
-                "babel-plugin-undefined-to-void": "1.1.6",
-                "babylon": "5.8.38",
-                "bluebird": "2.11.0",
-                "chalk": "1.1.3",
-                "convert-source-map": "1.3.0",
-                "core-js": "1.2.7",
-                "debug": "2.3.3",
-                "detect-indent": "3.0.1",
-                "esutils": "2.0.2",
-                "fs-readdir-recursive": "0.1.2",
-                "globals": "6.4.1",
-                "home-or-tmp": "1.0.0",
-                "is-integer": "1.0.6",
+                "babel-plugin-constant-folding": "^1.0.1",
+                "babel-plugin-dead-code-elimination": "^1.0.2",
+                "babel-plugin-eval": "^1.0.1",
+                "babel-plugin-inline-environment-variables": "^1.0.1",
+                "babel-plugin-jscript": "^1.0.4",
+                "babel-plugin-member-expression-literals": "^1.0.1",
+                "babel-plugin-property-literals": "^1.0.1",
+                "babel-plugin-proto-to-assign": "^1.0.3",
+                "babel-plugin-react-constant-elements": "^1.0.3",
+                "babel-plugin-react-display-name": "^1.0.3",
+                "babel-plugin-remove-console": "^1.0.1",
+                "babel-plugin-remove-debugger": "^1.0.1",
+                "babel-plugin-runtime": "^1.0.7",
+                "babel-plugin-undeclared-variables-check": "^1.0.2",
+                "babel-plugin-undefined-to-void": "^1.1.6",
+                "babylon": "^5.8.38",
+                "bluebird": "^2.9.33",
+                "chalk": "^1.0.0",
+                "convert-source-map": "^1.1.0",
+                "core-js": "^1.0.0",
+                "debug": "^2.1.1",
+                "detect-indent": "^3.0.0",
+                "esutils": "^2.0.0",
+                "fs-readdir-recursive": "^0.1.0",
+                "globals": "^6.4.0",
+                "home-or-tmp": "^1.0.0",
+                "is-integer": "^1.0.4",
                 "js-tokens": "1.0.1",
-                "json5": "0.4.0",
-                "lodash": "3.10.1",
-                "minimatch": "2.0.10",
-                "output-file-sync": "1.1.2",
-                "path-exists": "1.0.0",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.6",
+                "json5": "^0.4.0",
+                "lodash": "^3.10.0",
+                "minimatch": "^2.0.3",
+                "output-file-sync": "^1.1.0",
+                "path-exists": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "private": "^0.1.6",
                 "regenerator": "0.8.40",
-                "regexpu": "1.3.0",
-                "repeating": "1.1.3",
-                "resolve": "1.1.7",
-                "shebang-regex": "1.0.0",
-                "slash": "1.0.0",
-                "source-map": "0.5.6",
-                "source-map-support": "0.2.10",
-                "to-fast-properties": "1.0.2",
-                "trim-right": "1.0.1",
-                "try-resolve": "1.0.1"
+                "regexpu": "^1.3.0",
+                "repeating": "^1.1.2",
+                "resolve": "^1.1.6",
+                "shebang-regex": "^1.0.0",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.0",
+                "source-map-support": "^0.2.10",
+                "to-fast-properties": "^1.0.0",
+                "trim-right": "^1.0.0",
+                "try-resolve": "^1.0.0"
               },
               "dependencies": {
                 "babel-plugin-constant-folding": {
@@ -21239,7 +20774,7 @@
                   "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
                   "dev": true,
                   "requires": {
-                    "lodash": "3.10.1"
+                    "lodash": "^3.9.3"
                   }
                 },
                 "babel-plugin-react-constant-elements": {
@@ -21278,7 +20813,7 @@
                   "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
                   "dev": true,
                   "requires": {
-                    "leven": "1.0.2"
+                    "leven": "^1.0.2"
                   },
                   "dependencies": {
                     "leven": {
@@ -21313,11 +20848,11 @@
                   "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
+                    "ansi-styles": "^2.2.1",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -21338,7 +20873,7 @@
                       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -21355,7 +20890,7 @@
                       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -21409,9 +20944,9 @@
                   "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
                   "dev": true,
                   "requires": {
-                    "get-stdin": "4.0.1",
-                    "minimist": "1.2.0",
-                    "repeating": "1.1.3"
+                    "get-stdin": "^4.0.1",
+                    "minimist": "^1.1.0",
+                    "repeating": "^1.1.0"
                   },
                   "dependencies": {
                     "get-stdin": {
@@ -21452,8 +20987,8 @@
                   "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
                   "dev": true,
                   "requires": {
-                    "os-tmpdir": "1.0.2",
-                    "user-home": "1.1.1"
+                    "os-tmpdir": "^1.0.1",
+                    "user-home": "^1.1.1"
                   },
                   "dependencies": {
                     "os-tmpdir": {
@@ -21476,7 +21011,7 @@
                   "integrity": "sha1-UnOBn62ogNEj4awAqTjnFy3Y2V4=",
                   "dev": true,
                   "requires": {
-                    "is-finite": "1.0.2"
+                    "is-finite": "^1.0.0"
                   },
                   "dependencies": {
                     "is-finite": {
@@ -21485,7 +21020,7 @@
                       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
                       "dev": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -21522,7 +21057,7 @@
                   "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.6"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -21531,7 +21066,7 @@
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -21557,9 +21092,9 @@
                   "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11",
-                    "mkdirp": "0.5.1",
-                    "object-assign": "4.1.0"
+                    "graceful-fs": "^4.1.4",
+                    "mkdirp": "^0.5.1",
+                    "object-assign": "^4.1.0"
                   },
                   "dependencies": {
                     "graceful-fs": {
@@ -21617,12 +21152,12 @@
                   "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
                   "dev": true,
                   "requires": {
-                    "commoner": "0.10.8",
-                    "defs": "1.1.1",
-                    "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                    "private": "0.1.6",
+                    "commoner": "~0.10.3",
+                    "defs": "~1.1.0",
+                    "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                    "private": "~0.1.5",
                     "recast": "0.10.33",
-                    "through": "2.3.8"
+                    "through": "~2.3.8"
                   },
                   "dependencies": {
                     "commoner": {
@@ -21631,15 +21166,15 @@
                       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
                       "dev": true,
                       "requires": {
-                        "commander": "2.9.0",
-                        "detective": "4.3.2",
-                        "glob": "5.0.15",
-                        "graceful-fs": "4.1.11",
-                        "iconv-lite": "0.4.15",
-                        "mkdirp": "0.5.1",
-                        "private": "0.1.6",
-                        "q": "1.4.1",
-                        "recast": "0.11.18"
+                        "commander": "^2.5.0",
+                        "detective": "^4.3.1",
+                        "glob": "^5.0.15",
+                        "graceful-fs": "^4.1.2",
+                        "iconv-lite": "^0.4.5",
+                        "mkdirp": "^0.5.0",
+                        "private": "^0.1.6",
+                        "q": "^1.1.2",
+                        "recast": "^0.11.17"
                       },
                       "dependencies": {
                         "commander": {
@@ -21648,7 +21183,7 @@
                           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                           "dev": true,
                           "requires": {
-                            "graceful-readlink": "1.0.1"
+                            "graceful-readlink": ">= 1.0.0"
                           },
                           "dependencies": {
                             "graceful-readlink": {
@@ -21665,8 +21200,8 @@
                           "integrity": "sha1-d2l+LnlHrD/nyOJqbW8RUjWvqRw=",
                           "dev": true,
                           "requires": {
-                            "acorn": "3.3.0",
-                            "defined": "1.0.0"
+                            "acorn": "^3.1.0",
+                            "defined": "^1.0.0"
                           },
                           "dependencies": {
                             "acorn": {
@@ -21689,11 +21224,11 @@
                           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                           "dev": true,
                           "requires": {
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "2.0.10",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "2 || 3",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "inflight": {
@@ -21702,8 +21237,8 @@
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "dev": true,
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -21726,7 +21261,7 @@
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "dev": true,
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -21781,9 +21316,9 @@
                           "dev": true,
                           "requires": {
                             "ast-types": "0.9.2",
-                            "esprima": "3.1.2",
-                            "private": "0.1.6",
-                            "source-map": "0.5.6"
+                            "esprima": "~3.1.0",
+                            "private": "~0.1.5",
+                            "source-map": "~0.5.0"
                           },
                           "dependencies": {
                             "ast-types": {
@@ -21808,16 +21343,16 @@
                       "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
                       "dev": true,
                       "requires": {
-                        "alter": "0.2.0",
-                        "ast-traverse": "0.1.1",
-                        "breakable": "1.0.0",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "simple-fmt": "0.1.0",
-                        "simple-is": "0.2.0",
-                        "stringmap": "0.2.2",
-                        "stringset": "0.2.1",
-                        "tryor": "0.1.2",
-                        "yargs": "3.27.0"
+                        "alter": "~0.2.0",
+                        "ast-traverse": "~0.1.1",
+                        "breakable": "~1.0.0",
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "simple-fmt": "~0.1.0",
+                        "simple-is": "~0.2.0",
+                        "stringmap": "~0.2.2",
+                        "stringset": "~0.2.1",
+                        "tryor": "~0.1.2",
+                        "yargs": "~3.27.0"
                       },
                       "dependencies": {
                         "alter": {
@@ -21826,7 +21361,7 @@
                           "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
                           "dev": true,
                           "requires": {
-                            "stable": "0.1.5"
+                            "stable": "~0.1.3"
                           },
                           "dependencies": {
                             "stable": {
@@ -21885,12 +21420,12 @@
                           "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
                           "dev": true,
                           "requires": {
-                            "camelcase": "1.2.1",
-                            "cliui": "2.1.0",
-                            "decamelize": "1.2.0",
-                            "os-locale": "1.4.0",
-                            "window-size": "0.1.4",
-                            "y18n": "3.2.1"
+                            "camelcase": "^1.2.1",
+                            "cliui": "^2.1.0",
+                            "decamelize": "^1.0.0",
+                            "os-locale": "^1.4.0",
+                            "window-size": "^0.1.2",
+                            "y18n": "^3.2.0"
                           },
                           "dependencies": {
                             "camelcase": {
@@ -21905,8 +21440,8 @@
                               "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                               "dev": true,
                               "requires": {
-                                "center-align": "0.1.3",
-                                "right-align": "0.1.3",
+                                "center-align": "^0.1.1",
+                                "right-align": "^0.1.1",
                                 "wordwrap": "0.0.2"
                               },
                               "dependencies": {
@@ -21916,8 +21451,8 @@
                                   "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                                   "dev": true,
                                   "requires": {
-                                    "align-text": "0.1.4",
-                                    "lazy-cache": "1.0.4"
+                                    "align-text": "^0.1.3",
+                                    "lazy-cache": "^1.0.3"
                                   },
                                   "dependencies": {
                                     "align-text": {
@@ -21926,9 +21461,9 @@
                                       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                                       "dev": true,
                                       "requires": {
-                                        "kind-of": "3.0.4",
-                                        "longest": "1.0.1",
-                                        "repeat-string": "1.6.1"
+                                        "kind-of": "^3.0.2",
+                                        "longest": "^1.0.1",
+                                        "repeat-string": "^1.5.2"
                                       },
                                       "dependencies": {
                                         "kind-of": {
@@ -21937,7 +21472,7 @@
                                           "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
                                           "dev": true,
                                           "requires": {
-                                            "is-buffer": "1.1.4"
+                                            "is-buffer": "^1.0.2"
                                           },
                                           "dependencies": {
                                             "is-buffer": {
@@ -21976,7 +21511,7 @@
                                   "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                                   "dev": true,
                                   "requires": {
-                                    "align-text": "0.1.4"
+                                    "align-text": "^0.1.1"
                                   },
                                   "dependencies": {
                                     "align-text": {
@@ -21985,9 +21520,9 @@
                                       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                                       "dev": true,
                                       "requires": {
-                                        "kind-of": "3.0.4",
-                                        "longest": "1.0.1",
-                                        "repeat-string": "1.6.1"
+                                        "kind-of": "^3.0.2",
+                                        "longest": "^1.0.1",
+                                        "repeat-string": "^1.5.2"
                                       },
                                       "dependencies": {
                                         "kind-of": {
@@ -21996,7 +21531,7 @@
                                           "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
                                           "dev": true,
                                           "requires": {
-                                            "is-buffer": "1.1.4"
+                                            "is-buffer": "^1.0.2"
                                           },
                                           "dependencies": {
                                             "is-buffer": {
@@ -22043,7 +21578,7 @@
                               "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
                               "dev": true,
                               "requires": {
-                                "lcid": "1.0.0"
+                                "lcid": "^1.0.0"
                               },
                               "dependencies": {
                                 "lcid": {
@@ -22052,7 +21587,7 @@
                                   "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                                   "dev": true,
                                   "requires": {
-                                    "invert-kv": "1.0.0"
+                                    "invert-kv": "^1.0.0"
                                   },
                                   "dependencies": {
                                     "invert-kv": {
@@ -22094,9 +21629,9 @@
                       "dev": true,
                       "requires": {
                         "ast-types": "0.8.12",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "private": "0.1.6",
-                        "source-map": "0.5.6"
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "private": "~0.1.5",
+                        "source-map": "~0.5.0"
                       },
                       "dependencies": {
                         "ast-types": {
@@ -22121,11 +21656,11 @@
                   "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
                   "dev": true,
                   "requires": {
-                    "esprima": "2.7.3",
-                    "recast": "0.10.43",
-                    "regenerate": "1.3.2",
-                    "regjsgen": "0.2.0",
-                    "regjsparser": "0.1.5"
+                    "esprima": "^2.6.0",
+                    "recast": "^0.10.10",
+                    "regenerate": "^1.2.1",
+                    "regjsgen": "^0.2.0",
+                    "regjsparser": "^0.1.4"
                   },
                   "dependencies": {
                     "esprima": {
@@ -22141,9 +21676,9 @@
                       "dev": true,
                       "requires": {
                         "ast-types": "0.8.15",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "private": "0.1.6",
-                        "source-map": "0.5.6"
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "private": "~0.1.5",
+                        "source-map": "~0.5.0"
                       },
                       "dependencies": {
                         "ast-types": {
@@ -22178,7 +21713,7 @@
                       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
                       "dev": true,
                       "requires": {
-                        "jsesc": "0.5.0"
+                        "jsesc": "~0.5.0"
                       },
                       "dependencies": {
                         "jsesc": {
@@ -22197,7 +21732,7 @@
                   "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
                   "dev": true,
                   "requires": {
-                    "is-finite": "1.0.2"
+                    "is-finite": "^1.0.0"
                   },
                   "dependencies": {
                     "is-finite": {
@@ -22206,7 +21741,7 @@
                       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
                       "dev": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -22252,7 +21787,7 @@
                       "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
                       "dev": true,
                       "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                       },
                       "dependencies": {
                         "amdefine": {
@@ -22291,19 +21826,19 @@
               "integrity": "sha1-lcxrCw6w3M5fjmrhj2o8xFoGv0A=",
               "dev": true,
               "requires": {
-                "async-disk-cache": "1.0.9",
-                "blank-object": "1.0.2",
-                "broccoli-plugin": "1.3.0",
-                "fs-tree-diff": "0.5.5",
-                "hash-for-dep": "1.0.3",
-                "heimdalljs": "0.2.3",
-                "heimdalljs-logger": "0.1.7",
-                "md5-hex": "1.3.0",
-                "mkdirp": "0.5.1",
-                "promise-map-series": "0.2.3",
-                "rsvp": "3.3.3",
-                "symlink-or-copy": "1.1.8",
-                "walk-sync": "0.3.1"
+                "async-disk-cache": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.0.0",
+                "fs-tree-diff": "^0.5.2",
+                "hash-for-dep": "^1.0.2",
+                "heimdalljs": "^0.2.1",
+                "heimdalljs-logger": "^0.1.7",
+                "md5-hex": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "promise-map-series": "^0.2.1",
+                "rsvp": "^3.0.18",
+                "symlink-or-copy": "^1.0.1",
+                "walk-sync": "^0.3.1"
               },
               "dependencies": {
                 "async-disk-cache": {
@@ -22312,11 +21847,11 @@
                   "integrity": "sha1-I7r7gjGE9GNAfkdOjV+HiZ9yymM=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.3.3",
+                    "debug": "^2.1.3",
                     "istextorbinary": "2.1.0",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.5.4",
-                    "rsvp": "3.3.3"
+                    "mkdirp": "^0.5.0",
+                    "rimraf": "^2.5.3",
+                    "rsvp": "^3.0.18"
                   },
                   "dependencies": {
                     "debug": {
@@ -22342,9 +21877,9 @@
                       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
                       "dev": true,
                       "requires": {
-                        "binaryextensions": "2.0.0",
-                        "editions": "1.3.3",
-                        "textextensions": "2.0.1"
+                        "binaryextensions": "1 || 2",
+                        "editions": "^1.1.1",
+                        "textextensions": "1 || 2"
                       },
                       "dependencies": {
                         "binaryextensions": {
@@ -22373,7 +21908,7 @@
                       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                       "dev": true,
                       "requires": {
-                        "glob": "7.1.1"
+                        "glob": "^7.0.5"
                       },
                       "dependencies": {
                         "glob": {
@@ -22382,12 +21917,12 @@
                           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                           "dev": true,
                           "requires": {
-                            "fs.realpath": "1.0.0",
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "3.0.3",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "fs.realpath": "^1.0.0",
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "^3.0.2",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "fs.realpath": {
@@ -22402,8 +21937,8 @@
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "dev": true,
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -22426,7 +21961,7 @@
                               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                               "dev": true,
                               "requires": {
-                                "brace-expansion": "1.1.6"
+                                "brace-expansion": "^1.0.0"
                               },
                               "dependencies": {
                                 "brace-expansion": {
@@ -22435,7 +21970,7 @@
                                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                                   "dev": true,
                                   "requires": {
-                                    "balanced-match": "0.4.2",
+                                    "balanced-match": "^0.4.1",
                                     "concat-map": "0.0.1"
                                   },
                                   "dependencies": {
@@ -22461,7 +21996,7 @@
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "dev": true,
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -22496,10 +22031,10 @@
                   "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
                   "dev": true,
                   "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.6",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
+                    "promise-map-series": "^0.2.1",
+                    "quick-temp": "^0.1.3",
+                    "rimraf": "^2.3.4",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "quick-temp": {
@@ -22508,9 +22043,9 @@
                       "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                       "dev": true,
                       "requires": {
-                        "mktemp": "0.4.0",
-                        "rimraf": "2.2.8",
-                        "underscore.string": "2.3.3"
+                        "mktemp": "~0.4.0",
+                        "rimraf": "~2.2.6",
+                        "underscore.string": "~2.3.3"
                       },
                       "dependencies": {
                         "mktemp": {
@@ -22539,7 +22074,7 @@
                       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                       "dev": true,
                       "requires": {
-                        "glob": "7.1.1"
+                        "glob": "^7.0.5"
                       },
                       "dependencies": {
                         "glob": {
@@ -22548,12 +22083,12 @@
                           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                           "dev": true,
                           "requires": {
-                            "fs.realpath": "1.0.0",
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "3.0.3",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "fs.realpath": "^1.0.0",
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "^3.0.2",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "fs.realpath": {
@@ -22568,8 +22103,8 @@
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "dev": true,
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -22592,7 +22127,7 @@
                               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                               "dev": true,
                               "requires": {
-                                "brace-expansion": "1.1.6"
+                                "brace-expansion": "^1.0.0"
                               },
                               "dependencies": {
                                 "brace-expansion": {
@@ -22601,7 +22136,7 @@
                                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                                   "dev": true,
                                   "requires": {
-                                    "balanced-match": "0.4.2",
+                                    "balanced-match": "^0.4.1",
                                     "concat-map": "0.0.1"
                                   },
                                   "dependencies": {
@@ -22627,7 +22162,7 @@
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "dev": true,
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -22656,10 +22191,10 @@
                   "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
                   "dev": true,
                   "requires": {
-                    "heimdalljs-logger": "0.1.7",
-                    "object-assign": "4.1.0",
-                    "path-posix": "1.0.0",
-                    "symlink-or-copy": "1.1.8"
+                    "heimdalljs-logger": "^0.1.7",
+                    "object-assign": "^4.1.0",
+                    "path-posix": "^1.0.0",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "object-assign": {
@@ -22682,7 +22217,7 @@
                   "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.2.1"
+                    "rsvp": "~3.2.1"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -22699,8 +22234,8 @@
                   "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
+                    "debug": "^2.2.0",
+                    "heimdalljs": "^0.2.0"
                   },
                   "dependencies": {
                     "debug": {
@@ -22728,7 +22263,7 @@
                   "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
                   "dev": true,
                   "requires": {
-                    "md5-o-matic": "0.1.1"
+                    "md5-o-matic": "^0.1.1"
                   },
                   "dependencies": {
                     "md5-o-matic": {
@@ -22762,7 +22297,7 @@
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   }
                 },
                 "symlink-or-copy": {
@@ -22777,8 +22312,8 @@
                   "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
                   "dev": true,
                   "requires": {
-                    "ensure-posix-path": "1.0.2",
-                    "matcher-collection": "1.0.4"
+                    "ensure-posix-path": "^1.0.0",
+                    "matcher-collection": "^1.0.0"
                   },
                   "dependencies": {
                     "ensure-posix-path": {
@@ -22793,7 +22328,7 @@
                       "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                       "dev": true,
                       "requires": {
-                        "minimatch": "3.0.3"
+                        "minimatch": "^3.0.2"
                       },
                       "dependencies": {
                         "minimatch": {
@@ -22802,7 +22337,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -22811,7 +22346,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -22849,8 +22384,8 @@
               "integrity": "sha1-tX8YoKzlY4CVFjijs2prc9hhm4s=",
               "dev": true,
               "requires": {
-                "broccoli-kitchen-sink-helpers": "0.3.1",
-                "resolve": "1.1.7"
+                "broccoli-kitchen-sink-helpers": "^0.3.1",
+                "resolve": "^1.1.6"
               },
               "dependencies": {
                 "broccoli-kitchen-sink-helpers": {
@@ -22859,8 +22394,8 @@
                   "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
                   "dev": true,
                   "requires": {
-                    "glob": "5.0.15",
-                    "mkdirp": "0.5.1"
+                    "glob": "^5.0.10",
+                    "mkdirp": "^0.5.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -22869,11 +22404,11 @@
                       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                       "dev": true,
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -22882,8 +22417,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -22906,7 +22441,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -22915,7 +22450,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -22941,7 +22476,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -22987,7 +22522,7 @@
               "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "dev": true,
               "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
               },
               "dependencies": {
                 "jsonify": {
@@ -23006,14 +22541,14 @@
           "integrity": "sha1-WQzcwCG7kFtsEh2HwtHVffRKKkg=",
           "dev": true,
           "requires": {
-            "broccoli-caching-writer": "2.3.1",
-            "broccoli-kitchen-sink-helpers": "0.3.1",
-            "broccoli-stew": "1.4.0",
-            "fast-sourcemap-concat": "1.1.0",
-            "fs-extra": "0.30.0",
-            "lodash.merge": "4.6.0",
-            "lodash.omit": "4.5.0",
-            "lodash.uniq": "4.5.0"
+            "broccoli-caching-writer": "^2.3.1",
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "broccoli-stew": "^1.3.3",
+            "fast-sourcemap-concat": "^1.0.1",
+            "fs-extra": "^0.30.0",
+            "lodash.merge": "^4.3.0",
+            "lodash.omit": "^4.1.0",
+            "lodash.uniq": "^4.2.0"
           },
           "dependencies": {
             "broccoli-caching-writer": {
@@ -23022,12 +22557,12 @@
               "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
               "dev": true,
               "requires": {
-                "broccoli-kitchen-sink-helpers": "0.2.9",
+                "broccoli-kitchen-sink-helpers": "^0.2.5",
                 "broccoli-plugin": "1.1.0",
-                "debug": "2.3.3",
-                "rimraf": "2.5.4",
-                "rsvp": "3.3.3",
-                "walk-sync": "0.2.7"
+                "debug": "^2.1.1",
+                "rimraf": "^2.2.8",
+                "rsvp": "^3.0.17",
+                "walk-sync": "^0.2.5"
               },
               "dependencies": {
                 "broccoli-kitchen-sink-helpers": {
@@ -23036,8 +22571,8 @@
                   "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
                   "dev": true,
                   "requires": {
-                    "glob": "5.0.15",
-                    "mkdirp": "0.5.1"
+                    "glob": "^5.0.10",
+                    "mkdirp": "^0.5.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -23046,11 +22581,11 @@
                       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                       "dev": true,
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -23059,8 +22594,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -23083,7 +22618,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -23092,7 +22627,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -23118,7 +22653,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -23162,10 +22697,10 @@
                   "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
                   "dev": true,
                   "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.6",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
+                    "promise-map-series": "^0.2.1",
+                    "quick-temp": "^0.1.3",
+                    "rimraf": "^2.3.4",
+                    "symlink-or-copy": "^1.0.1"
                   },
                   "dependencies": {
                     "promise-map-series": {
@@ -23174,7 +22709,7 @@
                       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                       "dev": true,
                       "requires": {
-                        "rsvp": "3.3.3"
+                        "rsvp": "^3.0.14"
                       }
                     },
                     "quick-temp": {
@@ -23183,9 +22718,9 @@
                       "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                       "dev": true,
                       "requires": {
-                        "mktemp": "0.4.0",
-                        "rimraf": "2.2.8",
-                        "underscore.string": "2.3.3"
+                        "mktemp": "~0.4.0",
+                        "rimraf": "~2.2.6",
+                        "underscore.string": "~2.3.3"
                       },
                       "dependencies": {
                         "mktemp": {
@@ -23239,7 +22774,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -23248,12 +22783,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -23268,8 +22803,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -23292,7 +22827,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -23301,7 +22836,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -23327,7 +22862,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -23354,8 +22889,8 @@
                   "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
                   "dev": true,
                   "requires": {
-                    "ensure-posix-path": "1.0.2",
-                    "matcher-collection": "1.0.4"
+                    "ensure-posix-path": "^1.0.0",
+                    "matcher-collection": "^1.0.0"
                   },
                   "dependencies": {
                     "ensure-posix-path": {
@@ -23370,7 +22905,7 @@
                       "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                       "dev": true,
                       "requires": {
-                        "minimatch": "3.0.3"
+                        "minimatch": "^3.0.2"
                       },
                       "dependencies": {
                         "minimatch": {
@@ -23379,7 +22914,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -23388,7 +22923,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -23420,8 +22955,8 @@
               "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
               "dev": true,
               "requires": {
-                "glob": "5.0.15",
-                "mkdirp": "0.5.1"
+                "glob": "^5.0.10",
+                "mkdirp": "^0.5.1"
               },
               "dependencies": {
                 "glob": {
@@ -23430,11 +22965,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -23443,8 +22978,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -23467,7 +23002,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -23476,7 +23011,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -23502,7 +23037,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -23546,17 +23081,17 @@
               "integrity": "sha1-G9sKGATWKkGdGQq8JqyzyRh4FU0=",
               "dev": true,
               "requires": {
-                "broccoli-funnel": "1.1.0",
-                "broccoli-merge-trees": "1.2.1",
-                "broccoli-persistent-filter": "1.2.11",
-                "chalk": "1.1.3",
-                "debug": "2.3.3",
-                "ensure-posix-path": "1.0.2",
-                "fs-extra": "0.30.0",
-                "minimatch": "3.0.3",
-                "resolve": "1.1.7",
-                "rsvp": "3.3.3",
-                "walk-sync": "0.3.1"
+                "broccoli-funnel": "^1.0.1",
+                "broccoli-merge-trees": "^1.0.0",
+                "broccoli-persistent-filter": "^1.1.6",
+                "chalk": "^1.1.3",
+                "debug": "^2.1.0",
+                "ensure-posix-path": "^1.0.1",
+                "fs-extra": "^0.30.0",
+                "minimatch": "^3.0.2",
+                "resolve": "^1.1.6",
+                "rsvp": "^3.0.16",
+                "walk-sync": "^0.3.0"
               },
               "dependencies": {
                 "broccoli-persistent-filter": {
@@ -23565,19 +23100,19 @@
                   "integrity": "sha1-lcxrCw6w3M5fjmrhj2o8xFoGv0A=",
                   "dev": true,
                   "requires": {
-                    "async-disk-cache": "1.0.9",
-                    "blank-object": "1.0.2",
-                    "broccoli-plugin": "1.3.0",
-                    "fs-tree-diff": "0.5.5",
-                    "hash-for-dep": "1.0.3",
-                    "heimdalljs": "0.2.3",
-                    "heimdalljs-logger": "0.1.7",
-                    "md5-hex": "1.3.0",
-                    "mkdirp": "0.5.1",
-                    "promise-map-series": "0.2.3",
-                    "rsvp": "3.3.3",
-                    "symlink-or-copy": "1.1.8",
-                    "walk-sync": "0.3.1"
+                    "async-disk-cache": "^1.0.0",
+                    "blank-object": "^1.0.1",
+                    "broccoli-plugin": "^1.0.0",
+                    "fs-tree-diff": "^0.5.2",
+                    "hash-for-dep": "^1.0.2",
+                    "heimdalljs": "^0.2.1",
+                    "heimdalljs-logger": "^0.1.7",
+                    "md5-hex": "^1.0.2",
+                    "mkdirp": "^0.5.1",
+                    "promise-map-series": "^0.2.1",
+                    "rsvp": "^3.0.18",
+                    "symlink-or-copy": "^1.0.1",
+                    "walk-sync": "^0.3.1"
                   },
                   "dependencies": {
                     "async-disk-cache": {
@@ -23586,11 +23121,11 @@
                       "integrity": "sha1-I7r7gjGE9GNAfkdOjV+HiZ9yymM=",
                       "dev": true,
                       "requires": {
-                        "debug": "2.3.3",
+                        "debug": "^2.1.3",
                         "istextorbinary": "2.1.0",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.5.4",
-                        "rsvp": "3.3.3"
+                        "mkdirp": "^0.5.0",
+                        "rimraf": "^2.5.3",
+                        "rsvp": "^3.0.18"
                       },
                       "dependencies": {
                         "istextorbinary": {
@@ -23599,9 +23134,9 @@
                           "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
                           "dev": true,
                           "requires": {
-                            "binaryextensions": "2.0.0",
-                            "editions": "1.3.3",
-                            "textextensions": "2.0.1"
+                            "binaryextensions": "1 || 2",
+                            "editions": "^1.1.1",
+                            "textextensions": "1 || 2"
                           },
                           "dependencies": {
                             "binaryextensions": {
@@ -23630,7 +23165,7 @@
                           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                           "dev": true,
                           "requires": {
-                            "glob": "7.1.1"
+                            "glob": "^7.0.5"
                           },
                           "dependencies": {
                             "glob": {
@@ -23639,12 +23174,12 @@
                               "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                               "dev": true,
                               "requires": {
-                                "fs.realpath": "1.0.0",
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.3",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.2",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                               },
                               "dependencies": {
                                 "fs.realpath": {
@@ -23659,8 +23194,8 @@
                                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                                   "dev": true,
                                   "requires": {
-                                    "once": "1.4.0",
-                                    "wrappy": "1.0.2"
+                                    "once": "^1.3.0",
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -23683,7 +23218,7 @@
                                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                                   "dev": true,
                                   "requires": {
-                                    "wrappy": "1.0.2"
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -23718,10 +23253,10 @@
                       "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
                       "dev": true,
                       "requires": {
-                        "promise-map-series": "0.2.3",
-                        "quick-temp": "0.1.6",
-                        "rimraf": "2.5.4",
-                        "symlink-or-copy": "1.1.8"
+                        "promise-map-series": "^0.2.1",
+                        "quick-temp": "^0.1.3",
+                        "rimraf": "^2.3.4",
+                        "symlink-or-copy": "^1.1.8"
                       },
                       "dependencies": {
                         "quick-temp": {
@@ -23730,9 +23265,9 @@
                           "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                           "dev": true,
                           "requires": {
-                            "mktemp": "0.4.0",
-                            "rimraf": "2.2.8",
-                            "underscore.string": "2.3.3"
+                            "mktemp": "~0.4.0",
+                            "rimraf": "~2.2.6",
+                            "underscore.string": "~2.3.3"
                           },
                           "dependencies": {
                             "mktemp": {
@@ -23761,7 +23296,7 @@
                           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                           "dev": true,
                           "requires": {
-                            "glob": "7.1.1"
+                            "glob": "^7.0.5"
                           },
                           "dependencies": {
                             "glob": {
@@ -23770,12 +23305,12 @@
                               "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                               "dev": true,
                               "requires": {
-                                "fs.realpath": "1.0.0",
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.3",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.2",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                               },
                               "dependencies": {
                                 "fs.realpath": {
@@ -23790,8 +23325,8 @@
                                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                                   "dev": true,
                                   "requires": {
-                                    "once": "1.4.0",
-                                    "wrappy": "1.0.2"
+                                    "once": "^1.3.0",
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -23814,7 +23349,7 @@
                                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                                   "dev": true,
                                   "requires": {
-                                    "wrappy": "1.0.2"
+                                    "wrappy": "1"
                                   },
                                   "dependencies": {
                                     "wrappy": {
@@ -23843,10 +23378,10 @@
                       "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
                       "dev": true,
                       "requires": {
-                        "heimdalljs-logger": "0.1.7",
-                        "object-assign": "4.1.0",
-                        "path-posix": "1.0.0",
-                        "symlink-or-copy": "1.1.8"
+                        "heimdalljs-logger": "^0.1.7",
+                        "object-assign": "^4.1.0",
+                        "path-posix": "^1.0.0",
+                        "symlink-or-copy": "^1.1.8"
                       },
                       "dependencies": {
                         "object-assign": {
@@ -23869,8 +23404,8 @@
                       "integrity": "sha1-tX8YoKzlY4CVFjijs2prc9hhm4s=",
                       "dev": true,
                       "requires": {
-                        "broccoli-kitchen-sink-helpers": "0.3.1",
-                        "resolve": "1.1.7"
+                        "broccoli-kitchen-sink-helpers": "^0.3.1",
+                        "resolve": "^1.1.6"
                       }
                     },
                     "heimdalljs": {
@@ -23879,7 +23414,7 @@
                       "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
                       "dev": true,
                       "requires": {
-                        "rsvp": "3.2.1"
+                        "rsvp": "~3.2.1"
                       },
                       "dependencies": {
                         "rsvp": {
@@ -23896,8 +23431,8 @@
                       "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                       "dev": true,
                       "requires": {
-                        "debug": "2.3.3",
-                        "heimdalljs": "0.2.3"
+                        "debug": "^2.2.0",
+                        "heimdalljs": "^0.2.0"
                       }
                     },
                     "md5-hex": {
@@ -23906,7 +23441,7 @@
                       "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
                       "dev": true,
                       "requires": {
-                        "md5-o-matic": "0.1.1"
+                        "md5-o-matic": "^0.1.1"
                       },
                       "dependencies": {
                         "md5-o-matic": {
@@ -23940,7 +23475,7 @@
                       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                       "dev": true,
                       "requires": {
-                        "rsvp": "3.3.3"
+                        "rsvp": "^3.0.14"
                       }
                     },
                     "symlink-or-copy": {
@@ -23957,11 +23492,11 @@
                   "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
+                    "ansi-styles": "^2.2.1",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -23982,7 +23517,7 @@
                       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -23999,7 +23534,7 @@
                       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -24047,7 +23582,7 @@
                   "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.6"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -24056,7 +23591,7 @@
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -24082,8 +23617,8 @@
                   "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
                   "dev": true,
                   "requires": {
-                    "ensure-posix-path": "1.0.2",
-                    "matcher-collection": "1.0.4"
+                    "ensure-posix-path": "^1.0.0",
+                    "matcher-collection": "^1.0.0"
                   },
                   "dependencies": {
                     "matcher-collection": {
@@ -24092,7 +23627,7 @@
                       "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                       "dev": true,
                       "requires": {
-                        "minimatch": "3.0.3"
+                        "minimatch": "^3.0.2"
                       }
                     }
                   }
@@ -24105,14 +23640,14 @@
               "integrity": "sha1-qAB2er7V7aAuZyOOwGOnCb5h+dQ=",
               "dev": true,
               "requires": {
-                "chalk": "0.5.1",
-                "debug": "2.3.3",
-                "fs-extra": "0.30.0",
-                "memory-streams": "0.1.0",
-                "mkdirp": "0.5.1",
-                "rsvp": "3.3.3",
-                "source-map": "0.4.4",
-                "source-map-url": "0.3.0"
+                "chalk": "^0.5.1",
+                "debug": "^2.2.0",
+                "fs-extra": "^0.30.0",
+                "memory-streams": "^0.1.0",
+                "mkdirp": "^0.5.0",
+                "rsvp": "^3.0.14",
+                "source-map": "^0.4.2",
+                "source-map-url": "^0.3.0"
               },
               "dependencies": {
                 "chalk": {
@@ -24121,11 +23656,11 @@
                   "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "1.1.0",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "0.1.0",
-                    "strip-ansi": "0.3.0",
-                    "supports-color": "0.2.0"
+                    "ansi-styles": "^1.1.0",
+                    "escape-string-regexp": "^1.0.0",
+                    "has-ansi": "^0.1.0",
+                    "strip-ansi": "^0.3.0",
+                    "supports-color": "^0.2.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -24146,7 +23681,7 @@
                       "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -24163,7 +23698,7 @@
                       "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.1"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -24205,7 +23740,7 @@
                   "integrity": "sha1-vsZYpx4/KLDwwvGxRQHC21R9X3o=",
                   "dev": true,
                   "requires": {
-                    "readable-stream": "1.0.34"
+                    "readable-stream": "~1.0.2"
                   },
                   "dependencies": {
                     "readable-stream": {
@@ -24214,10 +23749,10 @@
                       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                       "dev": true,
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -24271,7 +23806,7 @@
                   "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                   "dev": true,
                   "requires": {
-                    "amdefine": "1.0.1"
+                    "amdefine": ">=0.0.4"
                   },
                   "dependencies": {
                     "amdefine": {
@@ -24296,11 +23831,11 @@
               "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "2.4.0",
-                "klaw": "1.3.1",
-                "path-is-absolute": "1.0.1",
-                "rimraf": "2.5.4"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
               },
               "dependencies": {
                 "graceful-fs": {
@@ -24315,7 +23850,7 @@
                   "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11"
+                    "graceful-fs": "^4.1.6"
                   }
                 },
                 "klaw": {
@@ -24324,7 +23859,7 @@
                   "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11"
+                    "graceful-fs": "^4.1.9"
                   }
                 },
                 "path-is-absolute": {
@@ -24339,7 +23874,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -24348,12 +23883,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -24368,8 +23903,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -24392,7 +23927,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -24401,7 +23936,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -24427,7 +23962,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -24470,20 +24005,20 @@
           "integrity": "sha1-37kaN8kCRWRW3kpAoYgZSNZbJ9k=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.3.3",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "minimatch": "3.0.3",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.1"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "array-equal": {
@@ -24504,10 +24039,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "promise-map-series": {
@@ -24516,7 +24051,7 @@
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   }
                 },
                 "quick-temp": {
@@ -24525,9 +24060,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -24581,7 +24116,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               }
             },
             "fs-tree-diff": {
@@ -24590,10 +24125,10 @@
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "dev": true,
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "heimdalljs-logger": {
@@ -24602,8 +24137,8 @@
                   "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
+                    "debug": "^2.2.0",
+                    "heimdalljs": "^0.2.0"
                   }
                 },
                 "object-assign": {
@@ -24620,7 +24155,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -24637,7 +24172,7 @@
               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -24646,7 +24181,7 @@
                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.4.2",
+                    "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -24695,7 +24230,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -24704,12 +24239,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -24724,8 +24259,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -24748,7 +24283,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -24781,8 +24316,8 @@
               "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
               "dev": true,
               "requires": {
-                "ensure-posix-path": "1.0.2",
-                "matcher-collection": "1.0.4"
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
               },
               "dependencies": {
                 "ensure-posix-path": {
@@ -24797,7 +24332,7 @@
                   "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                   "dev": true,
                   "requires": {
-                    "minimatch": "3.0.3"
+                    "minimatch": "^3.0.2"
                   }
                 }
               }
@@ -24810,14 +24345,14 @@
           "integrity": "sha1-FqdJTtVtvmFhH2wtSBfPuq0qMFU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "heimdalljs-logger": "0.1.7",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           },
           "dependencies": {
             "broccoli-plugin": {
@@ -24826,10 +24361,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "promise-map-series": {
@@ -24838,7 +24373,7 @@
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   }
                 },
                 "quick-temp": {
@@ -24847,9 +24382,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -24889,7 +24424,7 @@
                   "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
                   "dev": true,
                   "requires": {
-                    "os-tmpdir": "1.0.2"
+                    "os-tmpdir": "~1.0.1"
                   },
                   "dependencies": {
                     "os-tmpdir": {
@@ -24908,7 +24443,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               },
               "dependencies": {
                 "blank-object": {
@@ -24925,10 +24460,10 @@
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "dev": true,
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "object-assign": {
@@ -24951,7 +24486,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -24968,8 +24503,8 @@
               "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3",
-                "heimdalljs": "0.2.3"
+                "debug": "^2.2.0",
+                "heimdalljs": "^0.2.0"
               },
               "dependencies": {
                 "debug": {
@@ -24997,7 +24532,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -25006,12 +24541,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -25026,8 +24561,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -25050,7 +24585,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -25059,7 +24594,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -25085,7 +24620,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -25120,7 +24655,7 @@
           "integrity": "sha1-yqKGt30bSF310vYsZ6bxmqi1gsQ=",
           "dev": true,
           "requires": {
-            "semver": "5.3.0"
+            "semver": "^5.3.0"
           },
           "dependencies": {
             "semver": {
@@ -25137,7 +24672,7 @@
           "integrity": "sha1-vDiXmOGkqTP1QoYwJeL7kdhW2kk=",
           "dev": true,
           "requires": {
-            "ember-test-helpers": "0.5.34"
+            "ember-test-helpers": "^0.5.32"
           },
           "dependencies": {
             "ember-test-helpers": {
@@ -25146,7 +24681,7 @@
               "integrity": "sha1-yEORCNHLodfYOMISIIpcQGFHG4M=",
               "dev": true,
               "requires": {
-                "klassy": "0.1.3"
+                "klassy": "^0.1.3"
               },
               "dependencies": {
                 "klassy": {
@@ -25191,15 +24726,15 @@
       "integrity": "sha1-Xo3j0DTGVZeTN0gCMFhHDsEjGts=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "git-tools": "0.1.4",
-        "make-array": "0.1.2",
-        "merge": "1.2.0",
-        "moment-timezone": "0.3.1",
-        "nopt": "3.0.6",
-        "rsvp": "3.3.3",
-        "semver": "4.3.6",
-        "silent-error": "1.0.1"
+        "chalk": "^1.0.0",
+        "git-tools": "^0.1.4",
+        "make-array": "^0.1.2",
+        "merge": "^1.2.0",
+        "moment-timezone": "^0.3.0",
+        "nopt": "^3.0.3",
+        "rsvp": "^3.0.17",
+        "semver": "^4.3.1",
+        "silent-error": "^1.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -25208,11 +24743,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -25233,7 +24768,7 @@
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -25250,7 +24785,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -25275,7 +24810,7 @@
           "integrity": "sha1-XkPllEO4pd7bOdumY9pJ55+UOXg=",
           "dev": true,
           "requires": {
-            "spawnback": "1.0.0"
+            "spawnback": "~1.0.0"
           },
           "dependencies": {
             "spawnback": {
@@ -25304,7 +24839,7 @@
           "integrity": "sha1-PvR4VrAtU7cYoQpewgI6opnge/U=",
           "dev": true,
           "requires": {
-            "moment": "2.17.1"
+            "moment": ">= 2.6.0"
           },
           "dependencies": {
             "moment": {
@@ -25321,7 +24856,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "1"
           },
           "dependencies": {
             "abbrev": {
@@ -25350,7 +24885,7 @@
           "integrity": "sha1-cbfVA9HG+UiCtRtWvoebETy0giw=",
           "dev": true,
           "requires": {
-            "debug": "2.3.3"
+            "debug": "^2.2.0"
           },
           "dependencies": {
             "debug": {
@@ -25380,7 +24915,7 @@
       "integrity": "sha1-lxYgk0pLkYPPeSPMA+F4uDqpB/0=",
       "dev": true,
       "requires": {
-        "broccoli-sri-hash": "2.1.2"
+        "broccoli-sri-hash": "^2.1.0"
       },
       "dependencies": {
         "broccoli-sri-hash": {
@@ -25389,11 +24924,11 @@
           "integrity": "sha1-vGmQXtejga0yXMDQLe0HEyjr8/M=",
           "dev": true,
           "requires": {
-            "broccoli-caching-writer": "2.3.1",
-            "mkdirp": "0.5.1",
-            "rsvp": "3.3.3",
-            "sri-toolbox": "0.2.0",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-caching-writer": "^2.2.0",
+            "mkdirp": "^0.5.1",
+            "rsvp": "^3.1.0",
+            "sri-toolbox": "^0.2.0",
+            "symlink-or-copy": "^1.0.1"
           },
           "dependencies": {
             "broccoli-caching-writer": {
@@ -25402,12 +24937,12 @@
               "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
               "dev": true,
               "requires": {
-                "broccoli-kitchen-sink-helpers": "0.2.9",
+                "broccoli-kitchen-sink-helpers": "^0.2.5",
                 "broccoli-plugin": "1.1.0",
-                "debug": "2.3.3",
-                "rimraf": "2.5.4",
-                "rsvp": "3.3.3",
-                "walk-sync": "0.2.7"
+                "debug": "^2.1.1",
+                "rimraf": "^2.2.8",
+                "rsvp": "^3.0.17",
+                "walk-sync": "^0.2.5"
               },
               "dependencies": {
                 "broccoli-kitchen-sink-helpers": {
@@ -25416,8 +24951,8 @@
                   "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
                   "dev": true,
                   "requires": {
-                    "glob": "5.0.15",
-                    "mkdirp": "0.5.1"
+                    "glob": "^5.0.10",
+                    "mkdirp": "^0.5.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -25426,11 +24961,11 @@
                       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                       "dev": true,
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -25439,8 +24974,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -25463,7 +24998,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -25472,7 +25007,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -25498,7 +25033,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -25525,10 +25060,10 @@
                   "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
                   "dev": true,
                   "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.6",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
+                    "promise-map-series": "^0.2.1",
+                    "quick-temp": "^0.1.3",
+                    "rimraf": "^2.3.4",
+                    "symlink-or-copy": "^1.0.1"
                   },
                   "dependencies": {
                     "promise-map-series": {
@@ -25537,7 +25072,7 @@
                       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                       "dev": true,
                       "requires": {
-                        "rsvp": "3.3.3"
+                        "rsvp": "^3.0.14"
                       }
                     },
                     "quick-temp": {
@@ -25546,9 +25081,9 @@
                       "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                       "dev": true,
                       "requires": {
-                        "mktemp": "0.4.0",
-                        "rimraf": "2.2.8",
-                        "underscore.string": "2.3.3"
+                        "mktemp": "~0.4.0",
+                        "rimraf": "~2.2.6",
+                        "underscore.string": "~2.3.3"
                       },
                       "dependencies": {
                         "mktemp": {
@@ -25596,7 +25131,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -25605,12 +25140,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -25625,8 +25160,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -25649,7 +25184,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -25658,7 +25193,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -25684,7 +25219,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -25711,8 +25246,8 @@
                   "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
                   "dev": true,
                   "requires": {
-                    "ensure-posix-path": "1.0.2",
-                    "matcher-collection": "1.0.4"
+                    "ensure-posix-path": "^1.0.0",
+                    "matcher-collection": "^1.0.0"
                   },
                   "dependencies": {
                     "ensure-posix-path": {
@@ -25727,7 +25262,7 @@
                       "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                       "dev": true,
                       "requires": {
-                        "minimatch": "3.0.3"
+                        "minimatch": "^3.0.2"
                       },
                       "dependencies": {
                         "minimatch": {
@@ -25736,7 +25271,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -25745,7 +25280,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -25822,7 +25357,7 @@
       "integrity": "sha1-MgjDK1S8J4MFbouw1c/pu68X/7I=",
       "dev": true,
       "requires": {
-        "broccoli-uglify-sourcemap": "1.4.2"
+        "broccoli-uglify-sourcemap": "^1.0.0"
       },
       "dependencies": {
         "broccoli-uglify-sourcemap": {
@@ -25831,15 +25366,15 @@
           "integrity": "sha1-HigK+9+qcAsvQhVfbEoDbDfmHKc=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.3.3",
-            "lodash.merge": "4.6.0",
-            "matcher-collection": "1.0.4",
-            "mkdirp": "0.5.1",
-            "source-map-url": "0.3.0",
-            "symlink-or-copy": "1.1.8",
-            "uglify-js": "2.7.5",
-            "walk-sync": "0.1.3"
+            "broccoli-plugin": "^1.2.1",
+            "debug": "^2.2.0",
+            "lodash.merge": "^4.5.1",
+            "matcher-collection": "^1.0.0",
+            "mkdirp": "^0.5.0",
+            "source-map-url": "^0.3.0",
+            "symlink-or-copy": "^1.0.1",
+            "uglify-js": "^2.6.0",
+            "walk-sync": "^0.1.3"
           },
           "dependencies": {
             "broccoli-plugin": {
@@ -25848,10 +25383,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "promise-map-series": {
@@ -25860,7 +25395,7 @@
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -25877,9 +25412,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -25908,7 +25443,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -25917,12 +25452,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -25937,8 +25472,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -25961,7 +25496,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -25970,7 +25505,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -25996,7 +25531,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -26048,7 +25583,7 @@
               "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
               "dev": true,
               "requires": {
-                "minimatch": "3.0.3"
+                "minimatch": "^3.0.2"
               },
               "dependencies": {
                 "minimatch": {
@@ -26057,7 +25592,7 @@
                   "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.6"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -26066,7 +25601,7 @@
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -26123,10 +25658,10 @@
               "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
               "dev": true,
               "requires": {
-                "async": "0.2.10",
-                "source-map": "0.5.6",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "async": "~0.2.6",
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
               },
               "dependencies": {
                 "async": {
@@ -26153,9 +25688,9 @@
                   "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                   "dev": true,
                   "requires": {
-                    "camelcase": "1.2.1",
-                    "cliui": "2.1.0",
-                    "decamelize": "1.2.0",
+                    "camelcase": "^1.0.2",
+                    "cliui": "^2.1.0",
+                    "decamelize": "^1.0.0",
                     "window-size": "0.1.0"
                   },
                   "dependencies": {
@@ -26171,8 +25706,8 @@
                       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                       "dev": true,
                       "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                       },
                       "dependencies": {
@@ -26182,8 +25717,8 @@
                           "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                           "dev": true,
                           "requires": {
-                            "align-text": "0.1.4",
-                            "lazy-cache": "1.0.4"
+                            "align-text": "^0.1.3",
+                            "lazy-cache": "^1.0.3"
                           },
                           "dependencies": {
                             "align-text": {
@@ -26192,9 +25727,9 @@
                               "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                               "dev": true,
                               "requires": {
-                                "kind-of": "3.0.4",
-                                "longest": "1.0.1",
-                                "repeat-string": "1.6.1"
+                                "kind-of": "^3.0.2",
+                                "longest": "^1.0.1",
+                                "repeat-string": "^1.5.2"
                               },
                               "dependencies": {
                                 "kind-of": {
@@ -26203,7 +25738,7 @@
                                   "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
                                   "dev": true,
                                   "requires": {
-                                    "is-buffer": "1.1.4"
+                                    "is-buffer": "^1.0.2"
                                   },
                                   "dependencies": {
                                     "is-buffer": {
@@ -26242,7 +25777,7 @@
                           "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                           "dev": true,
                           "requires": {
-                            "align-text": "0.1.4"
+                            "align-text": "^0.1.1"
                           },
                           "dependencies": {
                             "align-text": {
@@ -26251,9 +25786,9 @@
                               "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                               "dev": true,
                               "requires": {
-                                "kind-of": "3.0.4",
-                                "longest": "1.0.1",
-                                "repeat-string": "1.6.1"
+                                "kind-of": "^3.0.2",
+                                "longest": "^1.0.1",
+                                "repeat-string": "^1.5.2"
                               },
                               "dependencies": {
                                 "kind-of": {
@@ -26262,7 +25797,7 @@
                                   "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
                                   "dev": true,
                                   "requires": {
-                                    "is-buffer": "1.1.4"
+                                    "is-buffer": "^1.0.2"
                                   },
                                   "dependencies": {
                                     "is-buffer": {
@@ -26324,12 +25859,13 @@
       }
     },
     "ember-cli-version-checker": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.0.0.tgz",
-      "integrity": "sha1-4ffY5M3NdSrDXxYR5Nqog220xMc=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz",
+      "integrity": "sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==",
+      "dev": true,
       "requires": {
-        "resolve": "1.4.0",
-        "semver": "5.4.1"
+        "resolve": "^1.3.3",
+        "semver": "^5.3.0"
       }
     },
     "ember-component-css": {
@@ -26338,21 +25874,21 @@
       "integrity": "sha1-0yQIoJ+aZZKDA79aNRNReWtchds=",
       "dev": true,
       "requires": {
-        "broccoli-concat": "3.0.5",
-        "broccoli-funnel": "1.1.0",
-        "broccoli-merge-trees": "1.2.1",
-        "broccoli-persistent-filter": "1.2.11",
-        "broccoli-plugin": "1.3.0",
-        "ember-cli-babel": "5.1.10",
-        "ember-getowner-polyfill": "1.0.1",
-        "fs-tree-diff": "0.5.5",
-        "md5": "2.2.1",
-        "postcss": "5.2.6",
-        "postcss-less": "0.15.0",
-        "postcss-scss": "0.4.0",
-        "postcss-selector-namespace": "1.2.8",
-        "rsvp": "3.3.3",
-        "walk-sync": "0.3.1"
+        "broccoli-concat": "^3.0.5",
+        "broccoli-funnel": "^1.0.9",
+        "broccoli-merge-trees": "^1.1.5",
+        "broccoli-persistent-filter": "^1.2.6",
+        "broccoli-plugin": "^1.2.1",
+        "ember-cli-babel": "^5.1.7",
+        "ember-getowner-polyfill": "^1.0.1",
+        "fs-tree-diff": "^0.5.4",
+        "md5": "^2.1.0",
+        "postcss": "^5.2.6",
+        "postcss-less": "^0.15.0",
+        "postcss-scss": "^0.4.0",
+        "postcss-selector-namespace": "^1.2.8",
+        "rsvp": "^3.2.1",
+        "walk-sync": "^0.3.1"
       },
       "dependencies": {
         "broccoli-concat": {
@@ -26361,15 +25897,15 @@
           "integrity": "sha1-MG+0fnyqI+xyY5H+i1hHZZRutS4=",
           "dev": true,
           "requires": {
-            "broccoli-caching-writer": "3.0.3",
-            "broccoli-kitchen-sink-helpers": "0.3.1",
-            "broccoli-stew": "1.4.0",
-            "fast-sourcemap-concat": "1.1.0",
-            "fs-extra": "0.30.0",
-            "lodash.merge": "4.6.0",
-            "lodash.omit": "4.5.0",
-            "lodash.uniq": "4.5.0",
-            "mkdirp": "0.5.1"
+            "broccoli-caching-writer": "^3.0.0",
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "broccoli-stew": "^1.3.3",
+            "fast-sourcemap-concat": "^1.0.1",
+            "fs-extra": "^0.30.0",
+            "lodash.merge": "^4.3.0",
+            "lodash.omit": "^4.1.0",
+            "lodash.uniq": "^4.2.0",
+            "mkdirp": "^0.5.1"
           },
           "dependencies": {
             "broccoli-caching-writer": {
@@ -26378,12 +25914,12 @@
               "integrity": "sha1-C9LJapc41qarWQ8HujXFFX19tHY=",
               "dev": true,
               "requires": {
-                "broccoli-kitchen-sink-helpers": "0.3.1",
-                "broccoli-plugin": "1.3.0",
-                "debug": "2.3.3",
-                "rimraf": "2.5.4",
-                "rsvp": "3.3.3",
-                "walk-sync": "0.3.1"
+                "broccoli-kitchen-sink-helpers": "^0.3.1",
+                "broccoli-plugin": "^1.2.1",
+                "debug": "^2.1.1",
+                "rimraf": "^2.2.8",
+                "rsvp": "^3.0.17",
+                "walk-sync": "^0.3.0"
               },
               "dependencies": {
                 "debug": {
@@ -26409,7 +25945,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -26418,12 +25954,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -26438,8 +25974,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -26462,7 +25998,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -26471,7 +26007,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -26497,7 +26033,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -26526,8 +26062,8 @@
               "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
               "dev": true,
               "requires": {
-                "glob": "5.0.15",
-                "mkdirp": "0.5.1"
+                "glob": "^5.0.10",
+                "mkdirp": "^0.5.1"
               },
               "dependencies": {
                 "glob": {
@@ -26536,11 +26072,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -26549,8 +26085,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -26573,7 +26109,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -26582,7 +26118,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -26608,7 +26144,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -26635,17 +26171,17 @@
               "integrity": "sha1-G9sKGATWKkGdGQq8JqyzyRh4FU0=",
               "dev": true,
               "requires": {
-                "broccoli-funnel": "1.1.0",
-                "broccoli-merge-trees": "1.2.1",
-                "broccoli-persistent-filter": "1.2.11",
-                "chalk": "1.1.3",
-                "debug": "2.3.3",
-                "ensure-posix-path": "1.0.2",
-                "fs-extra": "0.30.0",
-                "minimatch": "3.0.3",
-                "resolve": "1.1.7",
-                "rsvp": "3.3.3",
-                "walk-sync": "0.3.1"
+                "broccoli-funnel": "^1.0.1",
+                "broccoli-merge-trees": "^1.0.0",
+                "broccoli-persistent-filter": "^1.1.6",
+                "chalk": "^1.1.3",
+                "debug": "^2.1.0",
+                "ensure-posix-path": "^1.0.1",
+                "fs-extra": "^0.30.0",
+                "minimatch": "^3.0.2",
+                "resolve": "^1.1.6",
+                "rsvp": "^3.0.16",
+                "walk-sync": "^0.3.0"
               },
               "dependencies": {
                 "chalk": {
@@ -26654,11 +26190,11 @@
                   "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
+                    "ansi-styles": "^2.2.1",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -26679,7 +26215,7 @@
                       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -26696,7 +26232,7 @@
                       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -26744,7 +26280,7 @@
                   "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.6"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -26753,7 +26289,7 @@
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -26787,14 +26323,14 @@
               "integrity": "sha1-qAB2er7V7aAuZyOOwGOnCb5h+dQ=",
               "dev": true,
               "requires": {
-                "chalk": "0.5.1",
-                "debug": "2.3.3",
-                "fs-extra": "0.30.0",
-                "memory-streams": "0.1.0",
-                "mkdirp": "0.5.1",
-                "rsvp": "3.3.3",
-                "source-map": "0.4.4",
-                "source-map-url": "0.3.0"
+                "chalk": "^0.5.1",
+                "debug": "^2.2.0",
+                "fs-extra": "^0.30.0",
+                "memory-streams": "^0.1.0",
+                "mkdirp": "^0.5.0",
+                "rsvp": "^3.0.14",
+                "source-map": "^0.4.2",
+                "source-map-url": "^0.3.0"
               },
               "dependencies": {
                 "chalk": {
@@ -26803,11 +26339,11 @@
                   "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "1.1.0",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "0.1.0",
-                    "strip-ansi": "0.3.0",
-                    "supports-color": "0.2.0"
+                    "ansi-styles": "^1.1.0",
+                    "escape-string-regexp": "^1.0.0",
+                    "has-ansi": "^0.1.0",
+                    "strip-ansi": "^0.3.0",
+                    "supports-color": "^0.2.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -26828,7 +26364,7 @@
                       "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -26845,7 +26381,7 @@
                       "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.1"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -26887,7 +26423,7 @@
                   "integrity": "sha1-vsZYpx4/KLDwwvGxRQHC21R9X3o=",
                   "dev": true,
                   "requires": {
-                    "readable-stream": "1.0.34"
+                    "readable-stream": "~1.0.2"
                   },
                   "dependencies": {
                     "readable-stream": {
@@ -26896,10 +26432,10 @@
                       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                       "dev": true,
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -26936,7 +26472,7 @@
                   "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                   "dev": true,
                   "requires": {
-                    "amdefine": "1.0.1"
+                    "amdefine": ">=0.0.4"
                   },
                   "dependencies": {
                     "amdefine": {
@@ -26961,11 +26497,11 @@
               "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "2.4.0",
-                "klaw": "1.3.1",
-                "path-is-absolute": "1.0.1",
-                "rimraf": "2.5.4"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
               },
               "dependencies": {
                 "graceful-fs": {
@@ -26980,7 +26516,7 @@
                   "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11"
+                    "graceful-fs": "^4.1.6"
                   }
                 },
                 "klaw": {
@@ -26989,7 +26525,7 @@
                   "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11"
+                    "graceful-fs": "^4.1.9"
                   }
                 },
                 "path-is-absolute": {
@@ -27004,7 +26540,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -27013,12 +26549,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -27033,8 +26569,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -27057,7 +26593,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -27066,7 +26602,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -27092,7 +26628,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -27152,20 +26688,20 @@
           "integrity": "sha1-37kaN8kCRWRW3kpAoYgZSNZbJ9k=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.3.3",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "minimatch": "3.0.3",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.1"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "array-equal": {
@@ -27209,7 +26745,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               }
             },
             "heimdalljs": {
@@ -27218,7 +26754,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -27235,7 +26771,7 @@
               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -27244,7 +26780,7 @@
                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.4.2",
+                    "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -27293,7 +26829,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -27302,12 +26838,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -27322,8 +26858,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -27346,7 +26882,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -27381,14 +26917,14 @@
           "integrity": "sha1-FqdJTtVtvmFhH2wtSBfPuq0qMFU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "heimdalljs-logger": "0.1.7",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           },
           "dependencies": {
             "can-symlink": {
@@ -27406,7 +26942,7 @@
                   "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
                   "dev": true,
                   "requires": {
-                    "os-tmpdir": "1.0.2"
+                    "os-tmpdir": "~1.0.1"
                   },
                   "dependencies": {
                     "os-tmpdir": {
@@ -27425,7 +26961,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               },
               "dependencies": {
                 "blank-object": {
@@ -27442,7 +26978,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -27459,8 +26995,8 @@
               "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3",
-                "heimdalljs": "0.2.3"
+                "debug": "^2.2.0",
+                "heimdalljs": "^0.2.0"
               },
               "dependencies": {
                 "debug": {
@@ -27488,7 +27024,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -27497,12 +27033,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -27517,8 +27053,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -27541,7 +27077,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -27550,7 +27086,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -27576,7 +27112,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -27611,19 +27147,19 @@
           "integrity": "sha1-lcxrCw6w3M5fjmrhj2o8xFoGv0A=",
           "dev": true,
           "requires": {
-            "async-disk-cache": "1.0.9",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "fs-tree-diff": "0.5.5",
-            "hash-for-dep": "1.0.3",
-            "heimdalljs": "0.2.3",
-            "heimdalljs-logger": "0.1.7",
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "promise-map-series": "0.2.3",
-            "rsvp": "3.3.3",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.1"
+            "async-disk-cache": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.0.0",
+            "fs-tree-diff": "^0.5.2",
+            "hash-for-dep": "^1.0.2",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "md5-hex": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "promise-map-series": "^0.2.1",
+            "rsvp": "^3.0.18",
+            "symlink-or-copy": "^1.0.1",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "async-disk-cache": {
@@ -27632,11 +27168,11 @@
               "integrity": "sha1-I7r7gjGE9GNAfkdOjV+HiZ9yymM=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3",
+                "debug": "^2.1.3",
                 "istextorbinary": "2.1.0",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.5.4",
-                "rsvp": "3.3.3"
+                "mkdirp": "^0.5.0",
+                "rimraf": "^2.5.3",
+                "rsvp": "^3.0.18"
               },
               "dependencies": {
                 "debug": {
@@ -27662,9 +27198,9 @@
                   "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
                   "dev": true,
                   "requires": {
-                    "binaryextensions": "2.0.0",
-                    "editions": "1.3.3",
-                    "textextensions": "2.0.1"
+                    "binaryextensions": "1 || 2",
+                    "editions": "^1.1.1",
+                    "textextensions": "1 || 2"
                   },
                   "dependencies": {
                     "binaryextensions": {
@@ -27693,7 +27229,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -27702,12 +27238,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -27722,8 +27258,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -27746,7 +27282,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -27755,7 +27291,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -27781,7 +27317,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -27816,8 +27352,8 @@
               "integrity": "sha1-tX8YoKzlY4CVFjijs2prc9hhm4s=",
               "dev": true,
               "requires": {
-                "broccoli-kitchen-sink-helpers": "0.3.1",
-                "resolve": "1.1.7"
+                "broccoli-kitchen-sink-helpers": "^0.3.1",
+                "resolve": "^1.1.6"
               },
               "dependencies": {
                 "broccoli-kitchen-sink-helpers": {
@@ -27826,8 +27362,8 @@
                   "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
                   "dev": true,
                   "requires": {
-                    "glob": "5.0.15",
-                    "mkdirp": "0.5.1"
+                    "glob": "^5.0.10",
+                    "mkdirp": "^0.5.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -27836,11 +27372,11 @@
                       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                       "dev": true,
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -27849,8 +27385,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -27873,7 +27409,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -27882,7 +27418,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -27908,7 +27444,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -27943,7 +27479,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -27960,8 +27496,8 @@
               "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3",
-                "heimdalljs": "0.2.3"
+                "debug": "^2.2.0",
+                "heimdalljs": "^0.2.0"
               },
               "dependencies": {
                 "debug": {
@@ -27989,7 +27525,7 @@
               "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
               "dev": true,
               "requires": {
-                "md5-o-matic": "0.1.1"
+                "md5-o-matic": "^0.1.1"
               },
               "dependencies": {
                 "md5-o-matic": {
@@ -28023,7 +27559,7 @@
               "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
               "dev": true,
               "requires": {
-                "rsvp": "3.3.3"
+                "rsvp": "^3.0.14"
               }
             },
             "symlink-or-copy": {
@@ -28040,10 +27576,10 @@
           "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
           "dev": true,
           "requires": {
-            "promise-map-series": "0.2.3",
-            "quick-temp": "0.1.6",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8"
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^2.3.4",
+            "symlink-or-copy": "^1.1.8"
           },
           "dependencies": {
             "promise-map-series": {
@@ -28052,7 +27588,7 @@
               "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
               "dev": true,
               "requires": {
-                "rsvp": "3.3.3"
+                "rsvp": "^3.0.14"
               }
             },
             "quick-temp": {
@@ -28061,9 +27597,9 @@
               "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
               "dev": true,
               "requires": {
-                "mktemp": "0.4.0",
-                "rimraf": "2.2.8",
-                "underscore.string": "2.3.3"
+                "mktemp": "~0.4.0",
+                "rimraf": "~2.2.6",
+                "underscore.string": "~2.3.3"
               },
               "dependencies": {
                 "mktemp": {
@@ -28092,7 +27628,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -28101,12 +27637,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -28121,8 +27657,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -28145,7 +27681,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -28154,7 +27690,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -28180,7 +27716,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -28215,7 +27751,7 @@
           "integrity": "sha1-9gox0l1kJGHaxLR0YYSvr39QhK4=",
           "dev": true,
           "requires": {
-            "ember-cli-babel": "5.1.10"
+            "ember-cli-babel": "^5.1.5"
           }
         },
         "fs-tree-diff": {
@@ -28224,10 +27760,10 @@
           "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
           "dev": true,
           "requires": {
-            "heimdalljs-logger": "0.1.7",
-            "object-assign": "4.1.0",
-            "path-posix": "1.0.0",
-            "symlink-or-copy": "1.1.8"
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
           },
           "dependencies": {
             "heimdalljs-logger": {
@@ -28236,8 +27772,8 @@
               "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3",
-                "heimdalljs": "0.2.3"
+                "debug": "^2.2.0",
+                "heimdalljs": "^0.2.0"
               },
               "dependencies": {
                 "debug": {
@@ -28263,7 +27799,7 @@
                   "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.2.1"
+                    "rsvp": "~3.2.1"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -28302,9 +27838,9 @@
           "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
           "dev": true,
           "requires": {
-            "charenc": "0.0.1",
-            "crypt": "0.0.1",
-            "is-buffer": "1.1.4"
+            "charenc": "~0.0.1",
+            "crypt": "~0.0.1",
+            "is-buffer": "~1.1.1"
           },
           "dependencies": {
             "charenc": {
@@ -28333,10 +27869,10 @@
           "integrity": "sha1-olLNZ81SWFA18X6a0Ss1E3p73Z4=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.1.9",
-            "source-map": "0.5.6",
-            "supports-color": "3.1.2"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.1.2"
           },
           "dependencies": {
             "chalk": {
@@ -28345,11 +27881,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "ansi-styles": {
@@ -28370,7 +27906,7 @@
                   "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "2.0.0"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -28387,7 +27923,7 @@
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "2.0.0"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -28424,7 +27960,7 @@
               "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
               "dev": true,
               "requires": {
-                "has-flag": "1.0.0"
+                "has-flag": "^1.0.0"
               },
               "dependencies": {
                 "has-flag": {
@@ -28443,7 +27979,7 @@
           "integrity": "sha1-uFjcPoUMxvFYtT5nWF//IPag/EU=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.6"
+            "postcss": "^5.0.21"
           }
         },
         "postcss-scss": {
@@ -28452,7 +27988,7 @@
           "integrity": "sha1-CHwFLFKbknDZWAvRJIoPk9O0DVc=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.6"
+            "postcss": "^5.2.5"
           }
         },
         "postcss-selector-namespace": {
@@ -28461,7 +27997,7 @@
           "integrity": "sha1-fdKmyZ1L6Y7Y9a9Wn10a3s7Vtuw=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.6"
+            "postcss": "^5.2.4"
           }
         },
         "rsvp": {
@@ -28476,8 +28012,8 @@
           "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
           "dev": true,
           "requires": {
-            "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.4"
+            "ensure-posix-path": "^1.0.0",
+            "matcher-collection": "^1.0.0"
           },
           "dependencies": {
             "ensure-posix-path": {
@@ -28492,7 +28028,7 @@
               "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
               "dev": true,
               "requires": {
-                "minimatch": "3.0.3"
+                "minimatch": "^3.0.2"
               },
               "dependencies": {
                 "minimatch": {
@@ -28501,7 +28037,7 @@
                   "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.6"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -28510,7 +28046,7 @@
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -28543,28 +28079,28 @@
       "dev": true,
       "requires": {
         "amd-name-resolver": "0.0.5",
-        "babel-plugin-feature-flags": "0.2.3",
-        "babel-plugin-filter-imports": "0.2.1",
-        "babel5-plugin-strip-class-callcheck": "5.1.0",
-        "babel5-plugin-strip-heimdall": "5.0.2",
-        "broccoli-babel-transpiler": "5.6.1",
-        "broccoli-file-creator": "1.1.1",
-        "broccoli-merge-trees": "1.2.1",
-        "chalk": "1.1.3",
-        "ember-cli-babel": "5.1.10",
-        "ember-cli-path-utils": "1.0.0",
-        "ember-cli-string-utils": "1.0.0",
-        "ember-cli-test-info": "1.0.0",
-        "ember-cli-version-checker": "1.2.0",
-        "ember-inflector": "1.9.6",
-        "ember-runtime-enumerable-includes-polyfill": "1.0.4",
+        "babel-plugin-feature-flags": "^0.2.1",
+        "babel-plugin-filter-imports": "^0.2.0",
+        "babel5-plugin-strip-class-callcheck": "^5.1.0",
+        "babel5-plugin-strip-heimdall": "^5.0.2",
+        "broccoli-babel-transpiler": "^5.5.0",
+        "broccoli-file-creator": "^1.0.0",
+        "broccoli-merge-trees": "^1.0.0",
+        "chalk": "^1.1.1",
+        "ember-cli-babel": "^5.1.6",
+        "ember-cli-path-utils": "^1.0.0",
+        "ember-cli-string-utils": "^1.0.0",
+        "ember-cli-test-info": "^1.0.0",
+        "ember-cli-version-checker": "^1.1.4",
+        "ember-inflector": "^1.9.4",
+        "ember-runtime-enumerable-includes-polyfill": "^1.0.0",
         "exists-sync": "0.0.3",
-        "git-repo-info": "1.3.1",
-        "heimdalljs": "0.3.0",
-        "inflection": "1.10.0",
-        "npm-git-info": "1.0.3",
-        "semver": "5.3.0",
-        "silent-error": "1.0.1"
+        "git-repo-info": "^1.1.2",
+        "heimdalljs": "^0.3.0",
+        "inflection": "^1.8.0",
+        "npm-git-info": "^1.0.0",
+        "semver": "^5.1.0",
+        "silent-error": "^1.0.0"
       },
       "dependencies": {
         "amd-name-resolver": {
@@ -28573,7 +28109,7 @@
           "integrity": "sha1-dpYtrIdu0zEbBdKcaljBTh7zMEs=",
           "dev": true,
           "requires": {
-            "ensure-posix-path": "1.0.2"
+            "ensure-posix-path": "^1.0.1"
           },
           "dependencies": {
             "ensure-posix-path": {
@@ -28590,7 +28126,7 @@
           "integrity": "sha1-gdge13vaIBQJj6gkOrzwOlUcvU0=",
           "dev": true,
           "requires": {
-            "json-stable-stringify": "1.0.1"
+            "json-stable-stringify": "^1.0.1"
           },
           "dependencies": {
             "json-stable-stringify": {
@@ -28599,7 +28135,7 @@
               "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "dev": true,
               "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
               },
               "dependencies": {
                 "jsonify": {
@@ -28618,7 +28154,7 @@
           "integrity": "sha1-eE+WqJLy9+0szwlVaIvYkWzS4hI=",
           "dev": true,
           "requires": {
-            "json-stable-stringify": "1.0.1"
+            "json-stable-stringify": "^1.0.1"
           },
           "dependencies": {
             "json-stable-stringify": {
@@ -28627,7 +28163,7 @@
               "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "dev": true,
               "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
               },
               "dependencies": {
                 "jsonify": {
@@ -28658,13 +28194,13 @@
           "integrity": "sha1-lxhNyxQLQKpX8/84Mwr8zGddCjw=",
           "dev": true,
           "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.1.0",
-            "broccoli-merge-trees": "1.2.1",
-            "broccoli-persistent-filter": "1.2.11",
-            "clone": "0.2.0",
-            "hash-for-dep": "1.0.3",
-            "json-stable-stringify": "1.0.1"
+            "babel-core": "^5.0.0",
+            "broccoli-funnel": "^1.0.0",
+            "broccoli-merge-trees": "^1.0.0",
+            "broccoli-persistent-filter": "^1.0.1",
+            "clone": "^0.2.0",
+            "hash-for-dep": "^1.0.2",
+            "json-stable-stringify": "^1.0.0"
           },
           "dependencies": {
             "babel-core": {
@@ -28673,52 +28209,52 @@
               "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
               "dev": true,
               "requires": {
-                "babel-plugin-constant-folding": "1.0.1",
-                "babel-plugin-dead-code-elimination": "1.0.2",
-                "babel-plugin-eval": "1.0.1",
-                "babel-plugin-inline-environment-variables": "1.0.1",
-                "babel-plugin-jscript": "1.0.4",
-                "babel-plugin-member-expression-literals": "1.0.1",
-                "babel-plugin-property-literals": "1.0.1",
-                "babel-plugin-proto-to-assign": "1.0.4",
-                "babel-plugin-react-constant-elements": "1.0.3",
-                "babel-plugin-react-display-name": "1.0.3",
-                "babel-plugin-remove-console": "1.0.1",
-                "babel-plugin-remove-debugger": "1.0.1",
-                "babel-plugin-runtime": "1.0.7",
-                "babel-plugin-undeclared-variables-check": "1.0.2",
-                "babel-plugin-undefined-to-void": "1.1.6",
-                "babylon": "5.8.38",
-                "bluebird": "2.11.0",
-                "chalk": "1.1.3",
-                "convert-source-map": "1.3.0",
-                "core-js": "1.2.7",
-                "debug": "2.3.3",
-                "detect-indent": "3.0.1",
-                "esutils": "2.0.2",
-                "fs-readdir-recursive": "0.1.2",
-                "globals": "6.4.1",
-                "home-or-tmp": "1.0.0",
-                "is-integer": "1.0.6",
+                "babel-plugin-constant-folding": "^1.0.1",
+                "babel-plugin-dead-code-elimination": "^1.0.2",
+                "babel-plugin-eval": "^1.0.1",
+                "babel-plugin-inline-environment-variables": "^1.0.1",
+                "babel-plugin-jscript": "^1.0.4",
+                "babel-plugin-member-expression-literals": "^1.0.1",
+                "babel-plugin-property-literals": "^1.0.1",
+                "babel-plugin-proto-to-assign": "^1.0.3",
+                "babel-plugin-react-constant-elements": "^1.0.3",
+                "babel-plugin-react-display-name": "^1.0.3",
+                "babel-plugin-remove-console": "^1.0.1",
+                "babel-plugin-remove-debugger": "^1.0.1",
+                "babel-plugin-runtime": "^1.0.7",
+                "babel-plugin-undeclared-variables-check": "^1.0.2",
+                "babel-plugin-undefined-to-void": "^1.1.6",
+                "babylon": "^5.8.38",
+                "bluebird": "^2.9.33",
+                "chalk": "^1.0.0",
+                "convert-source-map": "^1.1.0",
+                "core-js": "^1.0.0",
+                "debug": "^2.1.1",
+                "detect-indent": "^3.0.0",
+                "esutils": "^2.0.0",
+                "fs-readdir-recursive": "^0.1.0",
+                "globals": "^6.4.0",
+                "home-or-tmp": "^1.0.0",
+                "is-integer": "^1.0.4",
                 "js-tokens": "1.0.1",
-                "json5": "0.4.0",
-                "lodash": "3.10.1",
-                "minimatch": "2.0.10",
-                "output-file-sync": "1.1.2",
-                "path-exists": "1.0.0",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.6",
+                "json5": "^0.4.0",
+                "lodash": "^3.10.0",
+                "minimatch": "^2.0.3",
+                "output-file-sync": "^1.1.0",
+                "path-exists": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "private": "^0.1.6",
                 "regenerator": "0.8.40",
-                "regexpu": "1.3.0",
-                "repeating": "1.1.3",
-                "resolve": "1.1.7",
-                "shebang-regex": "1.0.0",
-                "slash": "1.0.0",
-                "source-map": "0.5.6",
-                "source-map-support": "0.2.10",
-                "to-fast-properties": "1.0.2",
-                "trim-right": "1.0.1",
-                "try-resolve": "1.0.1"
+                "regexpu": "^1.3.0",
+                "repeating": "^1.1.2",
+                "resolve": "^1.1.6",
+                "shebang-regex": "^1.0.0",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.0",
+                "source-map-support": "^0.2.10",
+                "to-fast-properties": "^1.0.0",
+                "trim-right": "^1.0.0",
+                "try-resolve": "^1.0.0"
               },
               "dependencies": {
                 "babel-plugin-constant-folding": {
@@ -28769,7 +28305,7 @@
                   "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
                   "dev": true,
                   "requires": {
-                    "lodash": "3.10.1"
+                    "lodash": "^3.9.3"
                   }
                 },
                 "babel-plugin-react-constant-elements": {
@@ -28808,7 +28344,7 @@
                   "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
                   "dev": true,
                   "requires": {
-                    "leven": "1.0.2"
+                    "leven": "^1.0.2"
                   },
                   "dependencies": {
                     "leven": {
@@ -28872,9 +28408,9 @@
                   "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
                   "dev": true,
                   "requires": {
-                    "get-stdin": "4.0.1",
-                    "minimist": "1.2.0",
-                    "repeating": "1.1.3"
+                    "get-stdin": "^4.0.1",
+                    "minimist": "^1.1.0",
+                    "repeating": "^1.1.0"
                   },
                   "dependencies": {
                     "get-stdin": {
@@ -28915,8 +28451,8 @@
                   "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
                   "dev": true,
                   "requires": {
-                    "os-tmpdir": "1.0.2",
-                    "user-home": "1.1.1"
+                    "os-tmpdir": "^1.0.1",
+                    "user-home": "^1.1.1"
                   },
                   "dependencies": {
                     "os-tmpdir": {
@@ -28939,7 +28475,7 @@
                   "integrity": "sha1-UnOBn62ogNEj4awAqTjnFy3Y2V4=",
                   "dev": true,
                   "requires": {
-                    "is-finite": "1.0.2"
+                    "is-finite": "^1.0.0"
                   },
                   "dependencies": {
                     "is-finite": {
@@ -28948,7 +28484,7 @@
                       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
                       "dev": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -28985,7 +28521,7 @@
                   "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.6"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -28994,7 +28530,7 @@
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -29020,9 +28556,9 @@
                   "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.11",
-                    "mkdirp": "0.5.1",
-                    "object-assign": "4.1.0"
+                    "graceful-fs": "^4.1.4",
+                    "mkdirp": "^0.5.1",
+                    "object-assign": "^4.1.0"
                   },
                   "dependencies": {
                     "graceful-fs": {
@@ -29080,12 +28616,12 @@
                   "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
                   "dev": true,
                   "requires": {
-                    "commoner": "0.10.8",
-                    "defs": "1.1.1",
-                    "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                    "private": "0.1.6",
+                    "commoner": "~0.10.3",
+                    "defs": "~1.1.0",
+                    "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                    "private": "~0.1.5",
                     "recast": "0.10.33",
-                    "through": "2.3.8"
+                    "through": "~2.3.8"
                   },
                   "dependencies": {
                     "commoner": {
@@ -29094,15 +28630,15 @@
                       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
                       "dev": true,
                       "requires": {
-                        "commander": "2.9.0",
-                        "detective": "4.3.2",
-                        "glob": "5.0.15",
-                        "graceful-fs": "4.1.11",
-                        "iconv-lite": "0.4.15",
-                        "mkdirp": "0.5.1",
-                        "private": "0.1.6",
-                        "q": "1.4.1",
-                        "recast": "0.11.18"
+                        "commander": "^2.5.0",
+                        "detective": "^4.3.1",
+                        "glob": "^5.0.15",
+                        "graceful-fs": "^4.1.2",
+                        "iconv-lite": "^0.4.5",
+                        "mkdirp": "^0.5.0",
+                        "private": "^0.1.6",
+                        "q": "^1.1.2",
+                        "recast": "^0.11.17"
                       },
                       "dependencies": {
                         "commander": {
@@ -29111,7 +28647,7 @@
                           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                           "dev": true,
                           "requires": {
-                            "graceful-readlink": "1.0.1"
+                            "graceful-readlink": ">= 1.0.0"
                           },
                           "dependencies": {
                             "graceful-readlink": {
@@ -29128,8 +28664,8 @@
                           "integrity": "sha1-d2l+LnlHrD/nyOJqbW8RUjWvqRw=",
                           "dev": true,
                           "requires": {
-                            "acorn": "3.3.0",
-                            "defined": "1.0.0"
+                            "acorn": "^3.1.0",
+                            "defined": "^1.0.0"
                           },
                           "dependencies": {
                             "acorn": {
@@ -29152,11 +28688,11 @@
                           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                           "dev": true,
                           "requires": {
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "2.0.10",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "2 || 3",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "inflight": {
@@ -29165,8 +28701,8 @@
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "dev": true,
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -29189,7 +28725,7 @@
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "dev": true,
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -29244,9 +28780,9 @@
                           "dev": true,
                           "requires": {
                             "ast-types": "0.9.2",
-                            "esprima": "3.1.2",
-                            "private": "0.1.6",
-                            "source-map": "0.5.6"
+                            "esprima": "~3.1.0",
+                            "private": "~0.1.5",
+                            "source-map": "~0.5.0"
                           },
                           "dependencies": {
                             "ast-types": {
@@ -29271,16 +28807,16 @@
                       "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
                       "dev": true,
                       "requires": {
-                        "alter": "0.2.0",
-                        "ast-traverse": "0.1.1",
-                        "breakable": "1.0.0",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "simple-fmt": "0.1.0",
-                        "simple-is": "0.2.0",
-                        "stringmap": "0.2.2",
-                        "stringset": "0.2.1",
-                        "tryor": "0.1.2",
-                        "yargs": "3.27.0"
+                        "alter": "~0.2.0",
+                        "ast-traverse": "~0.1.1",
+                        "breakable": "~1.0.0",
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "simple-fmt": "~0.1.0",
+                        "simple-is": "~0.2.0",
+                        "stringmap": "~0.2.2",
+                        "stringset": "~0.2.1",
+                        "tryor": "~0.1.2",
+                        "yargs": "~3.27.0"
                       },
                       "dependencies": {
                         "alter": {
@@ -29289,7 +28825,7 @@
                           "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
                           "dev": true,
                           "requires": {
-                            "stable": "0.1.5"
+                            "stable": "~0.1.3"
                           },
                           "dependencies": {
                             "stable": {
@@ -29348,12 +28884,12 @@
                           "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
                           "dev": true,
                           "requires": {
-                            "camelcase": "1.2.1",
-                            "cliui": "2.1.0",
-                            "decamelize": "1.2.0",
-                            "os-locale": "1.4.0",
-                            "window-size": "0.1.4",
-                            "y18n": "3.2.1"
+                            "camelcase": "^1.2.1",
+                            "cliui": "^2.1.0",
+                            "decamelize": "^1.0.0",
+                            "os-locale": "^1.4.0",
+                            "window-size": "^0.1.2",
+                            "y18n": "^3.2.0"
                           },
                           "dependencies": {
                             "camelcase": {
@@ -29368,8 +28904,8 @@
                               "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                               "dev": true,
                               "requires": {
-                                "center-align": "0.1.3",
-                                "right-align": "0.1.3",
+                                "center-align": "^0.1.1",
+                                "right-align": "^0.1.1",
                                 "wordwrap": "0.0.2"
                               },
                               "dependencies": {
@@ -29379,8 +28915,8 @@
                                   "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                                   "dev": true,
                                   "requires": {
-                                    "align-text": "0.1.4",
-                                    "lazy-cache": "1.0.4"
+                                    "align-text": "^0.1.3",
+                                    "lazy-cache": "^1.0.3"
                                   },
                                   "dependencies": {
                                     "align-text": {
@@ -29389,9 +28925,9 @@
                                       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                                       "dev": true,
                                       "requires": {
-                                        "kind-of": "3.0.4",
-                                        "longest": "1.0.1",
-                                        "repeat-string": "1.6.1"
+                                        "kind-of": "^3.0.2",
+                                        "longest": "^1.0.1",
+                                        "repeat-string": "^1.5.2"
                                       },
                                       "dependencies": {
                                         "kind-of": {
@@ -29400,7 +28936,7 @@
                                           "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
                                           "dev": true,
                                           "requires": {
-                                            "is-buffer": "1.1.4"
+                                            "is-buffer": "^1.0.2"
                                           },
                                           "dependencies": {
                                             "is-buffer": {
@@ -29439,7 +28975,7 @@
                                   "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                                   "dev": true,
                                   "requires": {
-                                    "align-text": "0.1.4"
+                                    "align-text": "^0.1.1"
                                   },
                                   "dependencies": {
                                     "align-text": {
@@ -29448,9 +28984,9 @@
                                       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                                       "dev": true,
                                       "requires": {
-                                        "kind-of": "3.0.4",
-                                        "longest": "1.0.1",
-                                        "repeat-string": "1.6.1"
+                                        "kind-of": "^3.0.2",
+                                        "longest": "^1.0.1",
+                                        "repeat-string": "^1.5.2"
                                       },
                                       "dependencies": {
                                         "kind-of": {
@@ -29459,7 +28995,7 @@
                                           "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
                                           "dev": true,
                                           "requires": {
-                                            "is-buffer": "1.1.4"
+                                            "is-buffer": "^1.0.2"
                                           },
                                           "dependencies": {
                                             "is-buffer": {
@@ -29506,7 +29042,7 @@
                               "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
                               "dev": true,
                               "requires": {
-                                "lcid": "1.0.0"
+                                "lcid": "^1.0.0"
                               },
                               "dependencies": {
                                 "lcid": {
@@ -29515,7 +29051,7 @@
                                   "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                                   "dev": true,
                                   "requires": {
-                                    "invert-kv": "1.0.0"
+                                    "invert-kv": "^1.0.0"
                                   },
                                   "dependencies": {
                                     "invert-kv": {
@@ -29557,9 +29093,9 @@
                       "dev": true,
                       "requires": {
                         "ast-types": "0.8.12",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "private": "0.1.6",
-                        "source-map": "0.5.6"
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "private": "~0.1.5",
+                        "source-map": "~0.5.0"
                       },
                       "dependencies": {
                         "ast-types": {
@@ -29584,11 +29120,11 @@
                   "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
                   "dev": true,
                   "requires": {
-                    "esprima": "2.7.3",
-                    "recast": "0.10.43",
-                    "regenerate": "1.3.2",
-                    "regjsgen": "0.2.0",
-                    "regjsparser": "0.1.5"
+                    "esprima": "^2.6.0",
+                    "recast": "^0.10.10",
+                    "regenerate": "^1.2.1",
+                    "regjsgen": "^0.2.0",
+                    "regjsparser": "^0.1.4"
                   },
                   "dependencies": {
                     "esprima": {
@@ -29604,9 +29140,9 @@
                       "dev": true,
                       "requires": {
                         "ast-types": "0.8.15",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "private": "0.1.6",
-                        "source-map": "0.5.6"
+                        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+                        "private": "~0.1.5",
+                        "source-map": "~0.5.0"
                       },
                       "dependencies": {
                         "ast-types": {
@@ -29641,7 +29177,7 @@
                       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
                       "dev": true,
                       "requires": {
-                        "jsesc": "0.5.0"
+                        "jsesc": "~0.5.0"
                       },
                       "dependencies": {
                         "jsesc": {
@@ -29660,7 +29196,7 @@
                   "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
                   "dev": true,
                   "requires": {
-                    "is-finite": "1.0.2"
+                    "is-finite": "^1.0.0"
                   },
                   "dependencies": {
                     "is-finite": {
@@ -29669,7 +29205,7 @@
                       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
                       "dev": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -29721,7 +29257,7 @@
                       "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
                       "dev": true,
                       "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                       },
                       "dependencies": {
                         "amdefine": {
@@ -29760,20 +29296,20 @@
               "integrity": "sha1-37kaN8kCRWRW3kpAoYgZSNZbJ9k=",
               "dev": true,
               "requires": {
-                "array-equal": "1.0.0",
-                "blank-object": "1.0.2",
-                "broccoli-plugin": "1.3.0",
-                "debug": "2.3.3",
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
                 "exists-sync": "0.0.4",
-                "fast-ordered-set": "1.0.3",
-                "fs-tree-diff": "0.5.5",
-                "heimdalljs": "0.2.3",
-                "minimatch": "3.0.3",
-                "mkdirp": "0.5.1",
-                "path-posix": "1.0.0",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8",
-                "walk-sync": "0.3.1"
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
               },
               "dependencies": {
                 "array-equal": {
@@ -29794,10 +29330,10 @@
                   "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
                   "dev": true,
                   "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.6",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
+                    "promise-map-series": "^0.2.1",
+                    "quick-temp": "^0.1.3",
+                    "rimraf": "^2.3.4",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "promise-map-series": {
@@ -29806,7 +29342,7 @@
                       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                       "dev": true,
                       "requires": {
-                        "rsvp": "3.3.3"
+                        "rsvp": "^3.0.14"
                       },
                       "dependencies": {
                         "rsvp": {
@@ -29823,9 +29359,9 @@
                       "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                       "dev": true,
                       "requires": {
-                        "mktemp": "0.4.0",
-                        "rimraf": "2.2.8",
-                        "underscore.string": "2.3.3"
+                        "mktemp": "~0.4.0",
+                        "rimraf": "~2.2.6",
+                        "underscore.string": "~2.3.3"
                       },
                       "dependencies": {
                         "mktemp": {
@@ -29879,7 +29415,7 @@
                   "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
                   "dev": true,
                   "requires": {
-                    "blank-object": "1.0.2"
+                    "blank-object": "^1.0.1"
                   }
                 },
                 "fs-tree-diff": {
@@ -29888,10 +29424,10 @@
                   "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
                   "dev": true,
                   "requires": {
-                    "heimdalljs-logger": "0.1.7",
-                    "object-assign": "4.1.0",
-                    "path-posix": "1.0.0",
-                    "symlink-or-copy": "1.1.8"
+                    "heimdalljs-logger": "^0.1.7",
+                    "object-assign": "^4.1.0",
+                    "path-posix": "^1.0.0",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "heimdalljs-logger": {
@@ -29900,8 +29436,8 @@
                       "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                       "dev": true,
                       "requires": {
-                        "debug": "2.3.3",
-                        "heimdalljs": "0.2.3"
+                        "debug": "^2.2.0",
+                        "heimdalljs": "^0.2.0"
                       }
                     },
                     "object-assign": {
@@ -29918,7 +29454,7 @@
                   "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.2.1"
+                    "rsvp": "~3.2.1"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -29935,7 +29471,7 @@
                   "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.6"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -29944,7 +29480,7 @@
                       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -29993,7 +29529,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -30002,12 +29538,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -30022,8 +29558,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -30046,7 +29582,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -30079,8 +29615,8 @@
                   "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
                   "dev": true,
                   "requires": {
-                    "ensure-posix-path": "1.0.2",
-                    "matcher-collection": "1.0.4"
+                    "ensure-posix-path": "^1.0.0",
+                    "matcher-collection": "^1.0.0"
                   },
                   "dependencies": {
                     "ensure-posix-path": {
@@ -30095,7 +29631,7 @@
                       "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                       "dev": true,
                       "requires": {
-                        "minimatch": "3.0.3"
+                        "minimatch": "^3.0.2"
                       }
                     }
                   }
@@ -30108,19 +29644,19 @@
               "integrity": "sha1-lcxrCw6w3M5fjmrhj2o8xFoGv0A=",
               "dev": true,
               "requires": {
-                "async-disk-cache": "1.0.9",
-                "blank-object": "1.0.2",
-                "broccoli-plugin": "1.3.0",
-                "fs-tree-diff": "0.5.5",
-                "hash-for-dep": "1.0.3",
-                "heimdalljs": "0.2.3",
-                "heimdalljs-logger": "0.1.7",
-                "md5-hex": "1.3.0",
-                "mkdirp": "0.5.1",
-                "promise-map-series": "0.2.3",
-                "rsvp": "3.3.3",
-                "symlink-or-copy": "1.1.8",
-                "walk-sync": "0.3.1"
+                "async-disk-cache": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.0.0",
+                "fs-tree-diff": "^0.5.2",
+                "hash-for-dep": "^1.0.2",
+                "heimdalljs": "^0.2.1",
+                "heimdalljs-logger": "^0.1.7",
+                "md5-hex": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "promise-map-series": "^0.2.1",
+                "rsvp": "^3.0.18",
+                "symlink-or-copy": "^1.0.1",
+                "walk-sync": "^0.3.1"
               },
               "dependencies": {
                 "async-disk-cache": {
@@ -30129,11 +29665,11 @@
                   "integrity": "sha1-I7r7gjGE9GNAfkdOjV+HiZ9yymM=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.3.3",
+                    "debug": "^2.1.3",
                     "istextorbinary": "2.1.0",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.5.4",
-                    "rsvp": "3.3.3"
+                    "mkdirp": "^0.5.0",
+                    "rimraf": "^2.5.3",
+                    "rsvp": "^3.0.18"
                   },
                   "dependencies": {
                     "debug": {
@@ -30159,9 +29695,9 @@
                       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
                       "dev": true,
                       "requires": {
-                        "binaryextensions": "2.0.0",
-                        "editions": "1.3.3",
-                        "textextensions": "2.0.1"
+                        "binaryextensions": "1 || 2",
+                        "editions": "^1.1.1",
+                        "textextensions": "1 || 2"
                       },
                       "dependencies": {
                         "binaryextensions": {
@@ -30190,7 +29726,7 @@
                       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                       "dev": true,
                       "requires": {
-                        "glob": "7.1.1"
+                        "glob": "^7.0.5"
                       },
                       "dependencies": {
                         "glob": {
@@ -30199,12 +29735,12 @@
                           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                           "dev": true,
                           "requires": {
-                            "fs.realpath": "1.0.0",
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "3.0.3",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "fs.realpath": "^1.0.0",
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "^3.0.2",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "fs.realpath": {
@@ -30219,8 +29755,8 @@
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "dev": true,
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -30243,7 +29779,7 @@
                               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                               "dev": true,
                               "requires": {
-                                "brace-expansion": "1.1.6"
+                                "brace-expansion": "^1.0.0"
                               },
                               "dependencies": {
                                 "brace-expansion": {
@@ -30252,7 +29788,7 @@
                                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                                   "dev": true,
                                   "requires": {
-                                    "balanced-match": "0.4.2",
+                                    "balanced-match": "^0.4.1",
                                     "concat-map": "0.0.1"
                                   },
                                   "dependencies": {
@@ -30278,7 +29814,7 @@
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "dev": true,
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -30313,10 +29849,10 @@
                   "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
                   "dev": true,
                   "requires": {
-                    "promise-map-series": "0.2.3",
-                    "quick-temp": "0.1.6",
-                    "rimraf": "2.5.4",
-                    "symlink-or-copy": "1.1.8"
+                    "promise-map-series": "^0.2.1",
+                    "quick-temp": "^0.1.3",
+                    "rimraf": "^2.3.4",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "quick-temp": {
@@ -30325,9 +29861,9 @@
                       "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                       "dev": true,
                       "requires": {
-                        "mktemp": "0.4.0",
-                        "rimraf": "2.2.8",
-                        "underscore.string": "2.3.3"
+                        "mktemp": "~0.4.0",
+                        "rimraf": "~2.2.6",
+                        "underscore.string": "~2.3.3"
                       },
                       "dependencies": {
                         "mktemp": {
@@ -30356,7 +29892,7 @@
                       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                       "dev": true,
                       "requires": {
-                        "glob": "7.1.1"
+                        "glob": "^7.0.5"
                       },
                       "dependencies": {
                         "glob": {
@@ -30365,12 +29901,12 @@
                           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                           "dev": true,
                           "requires": {
-                            "fs.realpath": "1.0.0",
-                            "inflight": "1.0.6",
-                            "inherits": "2.0.3",
-                            "minimatch": "3.0.3",
-                            "once": "1.4.0",
-                            "path-is-absolute": "1.0.1"
+                            "fs.realpath": "^1.0.0",
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "^3.0.2",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
                           },
                           "dependencies": {
                             "fs.realpath": {
@@ -30385,8 +29921,8 @@
                               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                               "dev": true,
                               "requires": {
-                                "once": "1.4.0",
-                                "wrappy": "1.0.2"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -30409,7 +29945,7 @@
                               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                               "dev": true,
                               "requires": {
-                                "brace-expansion": "1.1.6"
+                                "brace-expansion": "^1.0.0"
                               },
                               "dependencies": {
                                 "brace-expansion": {
@@ -30418,7 +29954,7 @@
                                   "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                                   "dev": true,
                                   "requires": {
-                                    "balanced-match": "0.4.2",
+                                    "balanced-match": "^0.4.1",
                                     "concat-map": "0.0.1"
                                   },
                                   "dependencies": {
@@ -30444,7 +29980,7 @@
                               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                               "dev": true,
                               "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                               },
                               "dependencies": {
                                 "wrappy": {
@@ -30473,10 +30009,10 @@
                   "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
                   "dev": true,
                   "requires": {
-                    "heimdalljs-logger": "0.1.7",
-                    "object-assign": "4.1.0",
-                    "path-posix": "1.0.0",
-                    "symlink-or-copy": "1.1.8"
+                    "heimdalljs-logger": "^0.1.7",
+                    "object-assign": "^4.1.0",
+                    "path-posix": "^1.0.0",
+                    "symlink-or-copy": "^1.1.8"
                   },
                   "dependencies": {
                     "object-assign": {
@@ -30499,7 +30035,7 @@
                   "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.2.1"
+                    "rsvp": "~3.2.1"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -30516,8 +30052,8 @@
                   "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
                   "dev": true,
                   "requires": {
-                    "debug": "2.3.3",
-                    "heimdalljs": "0.2.3"
+                    "debug": "^2.2.0",
+                    "heimdalljs": "^0.2.0"
                   },
                   "dependencies": {
                     "debug": {
@@ -30545,7 +30081,7 @@
                   "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
                   "dev": true,
                   "requires": {
-                    "md5-o-matic": "0.1.1"
+                    "md5-o-matic": "^0.1.1"
                   },
                   "dependencies": {
                     "md5-o-matic": {
@@ -30579,7 +30115,7 @@
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   }
                 },
                 "rsvp": {
@@ -30600,8 +30136,8 @@
                   "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
                   "dev": true,
                   "requires": {
-                    "ensure-posix-path": "1.0.2",
-                    "matcher-collection": "1.0.4"
+                    "ensure-posix-path": "^1.0.0",
+                    "matcher-collection": "^1.0.0"
                   },
                   "dependencies": {
                     "ensure-posix-path": {
@@ -30616,7 +30152,7 @@
                       "integrity": "sha1-L2auCGmZbynkPQtiyD3R1D5YF1U=",
                       "dev": true,
                       "requires": {
-                        "minimatch": "3.0.3"
+                        "minimatch": "^3.0.2"
                       },
                       "dependencies": {
                         "minimatch": {
@@ -30625,7 +30161,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -30634,7 +30170,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -30672,8 +30208,8 @@
               "integrity": "sha1-tX8YoKzlY4CVFjijs2prc9hhm4s=",
               "dev": true,
               "requires": {
-                "broccoli-kitchen-sink-helpers": "0.3.1",
-                "resolve": "1.1.7"
+                "broccoli-kitchen-sink-helpers": "^0.3.1",
+                "resolve": "^1.1.6"
               },
               "dependencies": {
                 "broccoli-kitchen-sink-helpers": {
@@ -30682,8 +30218,8 @@
                   "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
                   "dev": true,
                   "requires": {
-                    "glob": "5.0.15",
-                    "mkdirp": "0.5.1"
+                    "glob": "^5.0.10",
+                    "mkdirp": "^0.5.1"
                   },
                   "dependencies": {
                     "glob": {
@@ -30692,11 +30228,11 @@
                       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                       "dev": true,
                       "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "inflight": {
@@ -30705,8 +30241,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -30729,7 +30265,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -30738,7 +30274,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -30764,7 +30300,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -30816,7 +30352,7 @@
               "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "dev": true,
               "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
               },
               "dependencies": {
                 "jsonify": {
@@ -30835,12 +30371,12 @@
           "integrity": "sha1-GzW2fSFavfrdjUnutpSTw55sNFA=",
           "dev": true,
           "requires": {
-            "broccoli-kitchen-sink-helpers": "0.2.9",
-            "broccoli-plugin": "1.3.0",
-            "broccoli-writer": "0.1.1",
-            "mkdirp": "0.5.1",
-            "rsvp": "3.0.21",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-kitchen-sink-helpers": "~0.2.0",
+            "broccoli-plugin": "^1.1.0",
+            "broccoli-writer": "~0.1.1",
+            "mkdirp": "^0.5.1",
+            "rsvp": "~3.0.6",
+            "symlink-or-copy": "^1.0.1"
           },
           "dependencies": {
             "broccoli-kitchen-sink-helpers": {
@@ -30849,8 +30385,8 @@
               "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
               "dev": true,
               "requires": {
-                "glob": "5.0.15",
-                "mkdirp": "0.5.1"
+                "glob": "^5.0.10",
+                "mkdirp": "^0.5.1"
               },
               "dependencies": {
                 "glob": {
@@ -30859,11 +30395,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -30872,8 +30408,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -30896,7 +30432,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -30905,7 +30441,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -30931,7 +30467,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -30958,10 +30494,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "promise-map-series": {
@@ -30970,7 +30506,7 @@
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.0.21"
+                    "rsvp": "^3.0.14"
                   }
                 },
                 "quick-temp": {
@@ -30979,9 +30515,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -31010,7 +30546,7 @@
                   "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.1"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -31019,12 +30555,12 @@
                       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -31039,8 +30575,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -31063,7 +30599,7 @@
                           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "dev": true,
                           "requires": {
-                            "brace-expansion": "1.1.6"
+                            "brace-expansion": "^1.0.0"
                           },
                           "dependencies": {
                             "brace-expansion": {
@@ -31072,7 +30608,7 @@
                               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "dev": true,
                               "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                               },
                               "dependencies": {
@@ -31098,7 +30634,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -31127,8 +30663,8 @@
               "integrity": "sha1-1NcaqPKvvGejhmuRotp5CEuWqy0=",
               "dev": true,
               "requires": {
-                "quick-temp": "0.1.6",
-                "rsvp": "3.0.21"
+                "quick-temp": "^0.1.0",
+                "rsvp": "^3.0.6"
               },
               "dependencies": {
                 "quick-temp": {
@@ -31137,9 +30673,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -31201,14 +30737,14 @@
           "integrity": "sha1-FqdJTtVtvmFhH2wtSBfPuq0qMFU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.5",
-            "heimdalljs": "0.2.3",
-            "heimdalljs-logger": "0.1.7",
-            "rimraf": "2.5.4",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           },
           "dependencies": {
             "broccoli-plugin": {
@@ -31217,10 +30753,10 @@
               "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
               "dev": true,
               "requires": {
-                "promise-map-series": "0.2.3",
-                "quick-temp": "0.1.6",
-                "rimraf": "2.5.4",
-                "symlink-or-copy": "1.1.8"
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "promise-map-series": {
@@ -31229,7 +30765,7 @@
                   "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
                   "dev": true,
                   "requires": {
-                    "rsvp": "3.3.3"
+                    "rsvp": "^3.0.14"
                   },
                   "dependencies": {
                     "rsvp": {
@@ -31246,9 +30782,9 @@
                   "integrity": "sha1-piQqFcup+c29NBKHtcVp4xjuwwc=",
                   "dev": true,
                   "requires": {
-                    "mktemp": "0.4.0",
-                    "rimraf": "2.2.8",
-                    "underscore.string": "2.3.3"
+                    "mktemp": "~0.4.0",
+                    "rimraf": "~2.2.6",
+                    "underscore.string": "~2.3.3"
                   },
                   "dependencies": {
                     "mktemp": {
@@ -31288,7 +30824,7 @@
                   "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
                   "dev": true,
                   "requires": {
-                    "os-tmpdir": "1.0.2"
+                    "os-tmpdir": "~1.0.1"
                   },
                   "dependencies": {
                     "os-tmpdir": {
@@ -31307,7 +30843,7 @@
               "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
               "dev": true,
               "requires": {
-                "blank-object": "1.0.2"
+                "blank-object": "^1.0.1"
               },
               "dependencies": {
                 "blank-object": {
@@ -31324,10 +30860,10 @@
               "integrity": "sha1-eCW020VCJd0RTnq9WOiSb+Boy/8=",
               "dev": true,
               "requires": {
-                "heimdalljs-logger": "0.1.7",
-                "object-assign": "4.1.0",
-                "path-posix": "1.0.0",
-                "symlink-or-copy": "1.1.8"
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
               },
               "dependencies": {
                 "object-assign": {
@@ -31350,7 +30886,7 @@
               "integrity": "sha1-Nbgqak1zVB/E+4jS/isjYI+093k=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               },
               "dependencies": {
                 "rsvp": {
@@ -31367,8 +30903,8 @@
               "integrity": "sha1-EONAr1wiqBHjRSLZuTl2da1YnKQ=",
               "dev": true,
               "requires": {
-                "debug": "2.3.3",
-                "heimdalljs": "0.2.3"
+                "debug": "^2.2.0",
+                "heimdalljs": "^0.2.0"
               },
               "dependencies": {
                 "debug": {
@@ -31396,7 +30932,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.1.1"
+                "glob": "^7.0.5"
               },
               "dependencies": {
                 "glob": {
@@ -31405,12 +30941,12 @@
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -31425,8 +30961,8 @@
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -31449,7 +30985,7 @@
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.6"
+                        "brace-expansion": "^1.0.0"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -31458,7 +30994,7 @@
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
-                            "balanced-match": "0.4.2",
+                            "balanced-match": "^0.4.1",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -31484,7 +31020,7 @@
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -31519,11 +31055,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -31544,7 +31080,7 @@
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -31561,7 +31097,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -31598,7 +31134,7 @@
           "integrity": "sha1-7U6WDySel1I8+JHkrtIHLOhFd7Q=",
           "dev": true,
           "requires": {
-            "ember-cli-string-utils": "1.0.0"
+            "ember-cli-string-utils": "^1.0.0"
           }
         },
         "ember-cli-version-checker": {
@@ -31607,7 +31143,7 @@
           "integrity": "sha1-yqKGt30bSF310vYsZ6bxmqi1gsQ=",
           "dev": true,
           "requires": {
-            "semver": "5.3.0"
+            "semver": "^5.3.0"
           }
         },
         "ember-inflector": {
@@ -31616,7 +31152,7 @@
           "integrity": "sha1-V0sJNmSt5sZuhBhdeI7JntKXQa8=",
           "dev": true,
           "requires": {
-            "ember-cli-babel": "5.1.10"
+            "ember-cli-babel": "^5.1.6"
           }
         },
         "ember-runtime-enumerable-includes-polyfill": {
@@ -31625,8 +31161,8 @@
           "integrity": "sha1-FqdhLjR6Lt8H2osvLwnb/ucN66A=",
           "dev": true,
           "requires": {
-            "ember-cli-babel": "5.1.10",
-            "ember-cli-version-checker": "1.2.0"
+            "ember-cli-babel": "^5.1.6",
+            "ember-cli-version-checker": "^1.1.6"
           }
         },
         "exists-sync": {
@@ -31647,7 +31183,7 @@
           "integrity": "sha1-01lz2gMz59k5akkdV/cneTaR7o8=",
           "dev": true,
           "requires": {
-            "rsvp": "3.2.1"
+            "rsvp": "~3.2.1"
           },
           "dependencies": {
             "rsvp": {
@@ -31682,7 +31218,7 @@
           "integrity": "sha1-cbfVA9HG+UiCtRtWvoebETy0giw=",
           "dev": true,
           "requires": {
-            "debug": "2.3.3"
+            "debug": "^2.2.0"
           },
           "dependencies": {
             "debug": {
@@ -31712,16 +31248,17 @@
       "integrity": "sha1-8lfVJxJokyqJ1zkmec5NuJ1xVK8=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "5.1.10"
+        "ember-cli-babel": "^5.1.10"
       }
     },
     "ember-get-config": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.2.1.tgz",
       "integrity": "sha1-oTJczu/LRTTHj8bMsr6Ho/7aaBc=",
+      "dev": true,
       "requires": {
-        "broccoli-file-creator": "1.1.1",
-        "ember-cli-babel": "5.1.10"
+        "broccoli-file-creator": "^1.1.1",
+        "ember-cli-babel": "^5.1.6"
       }
     },
     "ember-inflector": {
@@ -31730,7 +31267,7 @@
       "integrity": "sha1-V0sJNmSt5sZuhBhdeI7JntKXQa8=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "5.1.10"
+        "ember-cli-babel": "^5.1.6"
       }
     },
     "ember-load-initializers": {
@@ -31740,45 +31277,92 @@
       "dev": true
     },
     "ember-lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/ember-lodash/-/ember-lodash-4.17.5.tgz",
-      "integrity": "sha512-KNXi6nosrNOyYmop4J+z3lBskZQe8077nJufY7ZqjCdKNrFH9cZ0FpwANZKcYqJe+srwp4RPOW9RaMdjTdFSvw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/ember-lodash/-/ember-lodash-4.18.0.tgz",
+      "integrity": "sha1-Rd5wDWpPaPHNYoiNkLUKpkd7moM=",
+      "dev": true,
       "requires": {
-        "broccoli-debug": "0.6.3",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "2.0.0",
-        "broccoli-string-replace": "0.1.2",
-        "ember-cli-babel": "6.8.2",
-        "lodash-es": "4.17.4"
+        "broccoli-debug": "^0.6.1",
+        "broccoli-funnel": "^2.0.1",
+        "broccoli-merge-trees": "^2.0.0",
+        "broccoli-string-replace": "^0.1.1",
+        "ember-cli-babel": "^6.10.0",
+        "lodash-es": "^4.17.4"
       },
       "dependencies": {
-        "broccoli-merge-trees": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
-          "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
+        "broccoli-funnel": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "merge-trees": "1.0.1"
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
           }
         },
         "ember-cli-babel": {
-          "version": "6.8.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz",
-          "integrity": "sha1-6sJ4WWT0dD9MgVzVPGKI8AzAh9c=",
+          "version": "6.16.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.16.0.tgz",
+          "integrity": "sha512-rzWkVdKVk2KSbQ81TxmLli+LWdBEqF+FHE83rUQXVOV4FguJDtP1w2AW08f8QjuztbnQ5+VUGCb7H0dL8UwOVw==",
+          "dev": true,
           "requires": {
-            "amd-name-resolver": "0.0.7",
-            "babel-plugin-debug-macros": "0.1.11",
-            "babel-plugin-ember-modules-api-polyfill": "2.0.1",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-polyfill": "6.26.0",
-            "babel-preset-env": "1.6.0",
-            "broccoli-babel-transpiler": "6.1.2",
-            "broccoli-debug": "0.6.3",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-source": "1.1.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "2.0.0"
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.3.2",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.4.5",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "broccoli-debug": {
+              "version": "0.6.4",
+              "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
+              "integrity": "sha512-CixMUndBqTljCc26i6ubhBrGbAWXpWBsGJFce6ZOr76Tul2Ev1xxM0tmf7OjSzdYhkr5BrPd/CNbR9VMPi+NBg==",
+              "dev": true,
+              "requires": {
+                "broccoli-plugin": "^1.2.1",
+                "fs-tree-diff": "^0.5.2",
+                "heimdalljs": "^0.2.1",
+                "heimdalljs-logger": "^0.1.7",
+                "symlink-or-copy": "^1.1.8",
+                "tree-sync": "^1.2.2"
+              }
+            }
           }
+        },
+        "semver": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+          "dev": true
         }
       }
     },
@@ -31788,8 +31372,8 @@
       "integrity": "sha1-5tJJ07WAZGjAuixnzOz3qiS3VL8=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "5.1.10",
-        "ember-cli-version-checker": "1.2.0"
+        "ember-cli-babel": "^5.1.3",
+        "ember-cli-version-checker": "^1.1.4"
       },
       "dependencies": {
         "ember-cli-version-checker": {
@@ -31798,7 +31382,7 @@
           "integrity": "sha1-yqKGt30bSF310vYsZ6bxmqi1gsQ=",
           "dev": true,
           "requires": {
-            "semver": "5.3.0"
+            "semver": "^5.3.0"
           },
           "dependencies": {
             "semver": {
@@ -31812,9 +31396,10 @@
       }
     },
     "ember-rfc176-data": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz",
-      "integrity": "sha512-pJE2w+sI22UDsYmudI4nCp3WcImpUzXwe9qHfpOcEu3yM/HD1nGpDRt6kZD0KUnDmqkLeik/nYyzEwN/NU6xxA=="
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.3.tgz",
+      "integrity": "sha1-J/ugjVQKdGOkNmxI6qGcWkSXGjk=",
+      "dev": true
     },
     "ember-route-action-helper": {
       "version": "2.0.0",
@@ -31822,8 +31407,8 @@
       "integrity": "sha1-jcgFTSrJQA4igvf9sLvM4DmJgio=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "5.1.10",
-        "ember-getowner-polyfill": "1.0.1"
+        "ember-cli-babel": "^5.1.6",
+        "ember-getowner-polyfill": "^1.0.0"
       },
       "dependencies": {
         "ember-getowner-polyfill": {
@@ -31832,7 +31417,7 @@
           "integrity": "sha1-9gox0l1kJGHaxLR0YYSvr39QhK4=",
           "dev": true,
           "requires": {
-            "ember-cli-babel": "5.1.10"
+            "ember-cli-babel": "^5.1.5"
           }
         }
       }
@@ -31840,64 +31425,390 @@
     "ensure-posix-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
-      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI="
+      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "exists-sync": {
       "version": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
-      "integrity": "sha1-uRAAC+27ETs3i4L19adjgQdiLc8="
+      "integrity": "sha1-uRAAC+27ETs3i4L19adjgQdiLc8=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
+      }
     },
     "fake-xml-http-request": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-1.6.0.tgz",
-      "integrity": "sha512-99XPwwSg89BfzPuv4XCpZxn3EbauMCgAQCxq9MzrvS6DFD73OON6AnUTicL4A0HZtYMBwCZBWVnRqGjZDgQkTg=="
+      "integrity": "sha512-99XPwwSg89BfzPuv4XCpZxn3EbauMCgAQCxq9MzrvS6DFD73OON6AnUTicL4A0HZtYMBwCZBWVnRqGjZDgQkTg==",
+      "dev": true
     },
     "faker": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/faker/-/faker-3.1.0.tgz",
-      "integrity": "sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8="
+      "integrity": "sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fast-ordered-set": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
       "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
+      "dev": true,
       "requires": {
-        "blank-object": "1.0.2"
+        "blank-object": "^1.0.1"
+      }
+    },
+    "fast-sourcemap-concat": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-1.4.0.tgz",
+      "integrity": "sha512-x90Wlx/2C83lfyg7h4oguTZN4MyaVfaiUSJQNpU+YEA0Odf9u659Opo44b0LfoVg9G/bOE++GdID/dkyja+XcA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "fs-extra": "^5.0.0",
+        "heimdalljs-logger": "^0.1.9",
+        "memory-streams": "^0.1.3",
+        "mkdirp": "^0.5.0",
+        "source-map": "^0.4.2",
+        "source-map-url": "^0.3.0",
+        "sourcemap-validator": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "find-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-index/-/find-index-1.1.0.tgz",
+      "integrity": "sha1-UwB8ec0wBA1oFteUWOiDfVxXBe8=",
+      "dev": true
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "fs-extra": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
       "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+      "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0"
       }
     },
     "fs-tree-diff": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.6.tgz",
       "integrity": "sha1-NCZldJ6NykBoALZyJoyPUHPz5iM=",
+      "dev": true,
       "requires": {
-        "heimdalljs-logger": "0.1.9",
-        "object-assign": "4.1.1",
-        "path-posix": "1.0.0",
-        "symlink-or-copy": "1.1.8"
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fstream": {
       "version": "1.0.11",
@@ -31905,10 +31816,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "fstream-ignore": {
@@ -31917,9 +31828,9 @@
       "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "minimatch": "3.0.4"
+        "fstream": "^1.0.0",
+        "inherits": "2",
+        "minimatch": "^3.0.0"
       }
     },
     "fstream-npm": {
@@ -31928,9 +31839,15 @@
       "integrity": "sha1-ftDRrBPXaG3Z4b9s64vic79tL4Y=",
       "dev": true,
       "requires": {
-        "fstream-ignore": "1.0.5",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+        "fstream-ignore": "^1.0.0",
+        "inherits": "2"
       }
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "github-url-from-username-repo": {
       "version": "1.0.2",
@@ -31942,56 +31859,83 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "hash-for-dep": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.0.tgz",
       "integrity": "sha512-nTAMv4FEqSmV/u/LnPnw0YZJP0Qve7lLv5D8q5Zu441gI/lBZCq3BwnoZjlOn/HBLoK9DgyY+qVhCzxb1dAAiA==",
+      "dev": true,
       "requires": {
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "resolve": "1.4.0"
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "heimdalljs": "^0.2.3",
+        "heimdalljs-logger": "^0.1.7",
+        "resolve": "^1.4.0"
       }
     },
     "heimdalljs": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
       "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+      "dev": true,
       "requires": {
-        "rsvp": "3.2.1"
+        "rsvp": "~3.2.1"
       },
       "dependencies": {
         "rsvp": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+          "dev": true
         }
       }
     },
@@ -31999,24 +31943,41 @@
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
       "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
+      "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "heimdalljs": "0.2.5"
+        "debug": "^2.2.0",
+        "heimdalljs": "^0.2.0"
       }
     },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "imurmurhash": {
@@ -32029,21 +31990,92 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
       "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -32057,31 +32089,80 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "isarray": {
       "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true,
-      "optional": true
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "istextorbinary": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
+      "dev": true,
       "requires": {
-        "binaryextensions": "2.0.0",
-        "editions": "1.3.3",
-        "textextensions": "2.1.0"
+        "binaryextensions": "1 || 2",
+        "editions": "^1.1.1",
+        "textextensions": "1 || 2"
       }
     },
     "jodid25519": {
@@ -32090,13 +32171,24 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+        "jsbn": "~0.1.0"
       }
     },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "jsbn": {
       "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -32107,7 +32199,8 @@
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.1",
@@ -32115,38 +32208,54 @@
       "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
       "dev": true
     },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
     },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
     },
     "kind-of": {
       "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
       "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
       "dev": true,
       "requires": {
-        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+        "is-buffer": "^1.0.2"
       }
     },
     "lazy-cache": {
@@ -32154,6 +32263,16 @@
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true,
       "optional": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
     },
     "loader.js": {
       "version": "4.0.11",
@@ -32164,12 +32283,303 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
+      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg==",
+      "dev": true
+    },
+    "lodash._basebind": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.3.0.tgz",
+      "integrity": "sha1-K1vEUqDhBhQ7IYafIzvbWHQX0kg=",
+      "dev": true,
+      "requires": {
+        "lodash._basecreate": "~2.3.0",
+        "lodash._setbinddata": "~2.3.0",
+        "lodash.isobject": "~2.3.0"
+      }
+    },
+    "lodash._basecreate": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz",
+      "integrity": "sha1-m4ioak3P97fzxh2Dovz8BnHsneA=",
+      "dev": true,
+      "requires": {
+        "lodash._renative": "~2.3.0",
+        "lodash.isobject": "~2.3.0",
+        "lodash.noop": "~2.3.0"
+      }
+    },
+    "lodash._basecreatecallback": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.3.0.tgz",
+      "integrity": "sha1-N7KrF1kaM56YjbMln81GAZ16w2I=",
+      "dev": true,
+      "requires": {
+        "lodash._setbinddata": "~2.3.0",
+        "lodash.bind": "~2.3.0",
+        "lodash.identity": "~2.3.0",
+        "lodash.support": "~2.3.0"
+      }
+    },
+    "lodash._basecreatewrapper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.3.0.tgz",
+      "integrity": "sha1-qgxhrZYETDkzN2ExSDqXWcNlEkc=",
+      "dev": true,
+      "requires": {
+        "lodash._basecreate": "~2.3.0",
+        "lodash._setbinddata": "~2.3.0",
+        "lodash._slice": "~2.3.0",
+        "lodash.isobject": "~2.3.0"
+      }
+    },
+    "lodash._createwrapper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.3.0.tgz",
+      "integrity": "sha1-0arhEC2t9EDo4G/BM6bt1/4UYHU=",
+      "dev": true,
+      "requires": {
+        "lodash._basebind": "~2.3.0",
+        "lodash._basecreatewrapper": "~2.3.0",
+        "lodash.isfunction": "~2.3.0"
+      }
+    },
+    "lodash._escapehtmlchar": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.3.0.tgz",
+      "integrity": "sha1-0D2mvYLu3zjcCltQPXQOzQ6JRZI=",
+      "dev": true,
+      "requires": {
+        "lodash._htmlescapes": "~2.3.0"
+      }
+    },
+    "lodash._escapestringchar": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.3.0.tgz",
+      "integrity": "sha1-zOc65g/G2lXSv4oGecI8orqxSfw=",
+      "dev": true
+    },
+    "lodash._htmlescapes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.3.0.tgz",
+      "integrity": "sha1-HKmIY8rfH6HYLITzXzHkBVagTzo=",
+      "dev": true
+    },
+    "lodash._objecttypes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.3.0.tgz",
+      "integrity": "sha1-aj6jmH3W7rgCGy1cnDA1Scwrrh4=",
+      "dev": true
+    },
+    "lodash._reinterpolate": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.3.0.tgz",
+      "integrity": "sha1-A+6dhcDlXL1ZDXFgiilb3aURKOw=",
+      "dev": true
+    },
+    "lodash._renative": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._renative/-/lodash._renative-2.3.0.tgz",
+      "integrity": "sha1-d9jt1M7SbdWXH54Vpfdy5OMX+9M=",
+      "dev": true
+    },
+    "lodash._reunescapedhtml": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.3.0.tgz",
+      "integrity": "sha1-25ILVax/P/glk5rOubosIxcT0k0=",
+      "dev": true,
+      "requires": {
+        "lodash._htmlescapes": "~2.3.0",
+        "lodash.keys": "~2.3.0"
+      }
+    },
+    "lodash._setbinddata": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.3.0.tgz",
+      "integrity": "sha1-5WEEkKzRMnfVmFjZW18nJ/FQjwQ=",
+      "dev": true,
+      "requires": {
+        "lodash._renative": "~2.3.0",
+        "lodash.noop": "~2.3.0"
+      }
+    },
+    "lodash._shimkeys": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.3.0.tgz",
+      "integrity": "sha1-YR+TFJ4+bHIQlrSHae8pU3rai6k=",
+      "dev": true,
+      "requires": {
+        "lodash._objecttypes": "~2.3.0"
+      }
+    },
+    "lodash._slice": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.3.0.tgz",
+      "integrity": "sha1-FHGYEyhZly5GgMoppZkshVZpqlw=",
+      "dev": true
+    },
+    "lodash.bind": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.3.0.tgz",
+      "integrity": "sha1-wqjhi2jl7MFS4rFoJmEW/qWwFsw=",
+      "dev": true,
+      "requires": {
+        "lodash._createwrapper": "~2.3.0",
+        "lodash._renative": "~2.3.0",
+        "lodash._slice": "~2.3.0"
+      }
+    },
+    "lodash.defaults": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.3.0.tgz",
+      "integrity": "sha1-qDKwAfE487uXIcKBmip8xa4h7SU=",
+      "dev": true,
+      "requires": {
+        "lodash._objecttypes": "~2.3.0",
+        "lodash.keys": "~2.3.0"
+      }
+    },
+    "lodash.defaultsdeep": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz",
+      "integrity": "sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=",
+      "dev": true
+    },
+    "lodash.escape": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.3.0.tgz",
+      "integrity": "sha1-hEw4xY+EThNi6+lnJhWbYs9fKlg=",
+      "dev": true,
+      "requires": {
+        "lodash._escapehtmlchar": "~2.3.0",
+        "lodash._reunescapedhtml": "~2.3.0",
+        "lodash.keys": "~2.3.0"
+      }
+    },
+    "lodash.foreach": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.3.0.tgz",
+      "integrity": "sha1-CDQEyR6EbudyRf3512UZxosq8Wg=",
+      "dev": true,
+      "requires": {
+        "lodash._basecreatecallback": "~2.3.0",
+        "lodash.forown": "~2.3.0"
+      }
+    },
+    "lodash.forown": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.3.0.tgz",
+      "integrity": "sha1-JPtKr4ANRfwtxgv+w84EyDajrX8=",
+      "dev": true,
+      "requires": {
+        "lodash._basecreatecallback": "~2.3.0",
+        "lodash._objecttypes": "~2.3.0",
+        "lodash.keys": "~2.3.0"
+      }
+    },
+    "lodash.identity": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.3.0.tgz",
+      "integrity": "sha1-awGiEMlIU1XCqRO0i2cRIZoXPe0=",
+      "dev": true
+    },
+    "lodash.isfunction": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.3.0.tgz",
+      "integrity": "sha1-aylz5HpkfPEucNZ2rqE2Q3BuUmc=",
+      "dev": true
+    },
+    "lodash.isobject": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.3.0.tgz",
+      "integrity": "sha1-LhbT/Fg9qYMZaJU/LY5tc0NPZ5k=",
+      "dev": true,
+      "requires": {
+        "lodash._objecttypes": "~2.3.0"
+      }
+    },
+    "lodash.keys": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz",
+      "integrity": "sha1-s1D0+Syqn0WkouzwGEVM8vKK4lM=",
+      "dev": true,
+      "requires": {
+        "lodash._renative": "~2.3.0",
+        "lodash._shimkeys": "~2.3.0",
+        "lodash.isobject": "~2.3.0"
+      }
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "dev": true
+    },
+    "lodash.noop": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.3.0.tgz",
+      "integrity": "sha1-MFnWKNUbv5N80qC2/Dp/ISpmnCw=",
+      "dev": true
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+      "dev": true
+    },
+    "lodash.support": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.3.0.tgz",
+      "integrity": "sha1-fq8DivTw1qq3drRKptz8gDNMm/0=",
+      "dev": true,
+      "requires": {
+        "lodash._renative": "~2.3.0"
+      }
+    },
+    "lodash.template": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.3.0.tgz",
+      "integrity": "sha1-Tj4pxDO0z+pnXsg15vEjkcYf0is=",
+      "dev": true,
+      "requires": {
+        "lodash._escapestringchar": "~2.3.0",
+        "lodash._reinterpolate": "~2.3.0",
+        "lodash.defaults": "~2.3.0",
+        "lodash.escape": "~2.3.0",
+        "lodash.keys": "~2.3.0",
+        "lodash.templatesettings": "~2.3.0",
+        "lodash.values": "~2.3.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.3.0.tgz",
+      "integrity": "sha1-MD0TLDQnEAQNWhjvqi1XL9A/jNw=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~2.3.0",
+        "lodash.escape": "~2.3.0"
+      }
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "lodash.values": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.3.0.tgz",
+      "integrity": "sha1-ypb75gogsLDsK6K6X8anZb0Uo7o=",
+      "dev": true,
+      "requires": {
+        "lodash.keys": "~2.3.0"
+      }
     },
     "longest": {
       "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -32180,48 +32590,120 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "matcher-collection": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
       "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
+      "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.2"
+      }
+    },
+    "md5-hex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+      "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+      "dev": true,
+      "requires": {
+        "md5-o-matic": "^0.1.1"
+      }
+    },
+    "md5-o-matic": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+      "dev": true
+    },
+    "memory-streams": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
+      "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~1.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
       }
     },
     "merge-trees": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
       "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+      "dev": true,
       "requires": {
-        "can-symlink": "1.0.0",
-        "fs-tree-diff": "0.5.6",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "rimraf": "2.6.2",
-        "symlink-or-copy": "1.1.8"
+        "can-symlink": "^1.0.0",
+        "fs-tree-diff": "^0.5.4",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0"
       }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -32229,12 +32711,26 @@
     "mktemp": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
-      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
+      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws=",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -32242,10 +32738,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "npm-package-arg": {
@@ -32254,42 +32750,79 @@
       "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "semver": "5.4.1"
+        "hosted-git-info": "^2.1.5",
+        "semver": "^5.1.0"
       }
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
       }
     },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -32300,56 +32833,107 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
     },
     "path-posix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
+      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "pretender": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/pretender/-/pretender-1.6.0.tgz",
-      "integrity": "sha512-Gk0CfA11KL99VIOrMwljEwtogl/4cLhFPk8JFugum3ryAJm7X8ZuR/pIOpUua256Rwr5JfYjyOPjqhAgOVs4nA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pretender/-/pretender-1.6.1.tgz",
+      "integrity": "sha1-d9HkKsjGspj1zUNTSodkXfA124w=",
+      "dev": true,
       "requires": {
-        "fake-xml-http-request": "1.6.0",
-        "route-recognizer": "0.3.3"
+        "fake-xml-http-request": "^1.6.0",
+        "route-recognizer": "^0.3.3"
       },
       "dependencies": {
         "route-recognizer": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.3.tgz",
-          "integrity": "sha1-HTZeJ/ppleCRZ199yUCowANTvSk="
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.4.tgz",
+          "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
+          "dev": true
         }
       }
     },
     "private": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true,
-      "optional": true
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
     },
     "promise-map-series": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+      "dev": true,
       "requires": {
-        "rsvp": "3.6.2"
+        "rsvp": "^3.0.14"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "quick-temp": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
       "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
+      "dev": true,
       "requires": {
-        "mktemp": "0.4.0",
-        "rimraf": "2.6.2",
-        "underscore.string": "3.3.4"
+        "mktemp": "~0.4.0",
+        "rimraf": "^2.5.4",
+        "underscore.string": "~3.3.4"
       }
     },
     "read-installed": {
@@ -32358,13 +32942,13 @@
       "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
       "dev": true,
       "requires": {
-        "debuglog": "1.0.1",
-        "graceful-fs": "4.1.11",
-        "read-package-json": "2.0.12",
-        "readdir-scoped-modules": "1.0.2",
-        "semver": "5.4.1",
-        "slide": "1.1.6",
-        "util-extend": "1.0.3"
+        "debuglog": "^1.0.1",
+        "graceful-fs": "^4.1.2",
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "slide": "~1.1.3",
+        "util-extend": "^1.0.1"
       }
     },
     "read-package-json": {
@@ -32373,26 +32957,25 @@
       "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "json-parse-better-errors": "1.0.1",
-        "normalize-package-data": "2.4.0",
-        "slash": "1.0.0"
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
+        "json-parse-better-errors": "^1.0.0",
+        "normalize-package-data": "^2.0.0",
+        "slash": "^1.0.0"
       }
     },
     "readable-stream": {
       "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
       "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+        "buffer-shims": "~1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdir-scoped-modules": {
@@ -32401,10 +32984,10 @@
       "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
       "dev": true,
       "requires": {
-        "debuglog": "1.0.1",
-        "dezalgo": "1.0.3",
-        "graceful-fs": "4.1.11",
-        "once": "1.4.0"
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
       }
     },
     "realize-package-specifier": {
@@ -32413,51 +32996,63 @@
       "integrity": "sha1-0N74gpUrjeP2frpekRmWYScfQfQ=",
       "dev": true,
       "requires": {
-        "dezalgo": "1.0.3",
-        "npm-package-arg": "4.2.1"
+        "dezalgo": "^1.0.1",
+        "npm-package-arg": "^4.1.1"
       }
     },
     "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.7"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
     },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
       "requires": {
-        "regenerate": "1.3.2",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
     },
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       }
     },
     "repeat-string": {
@@ -32469,16 +33064,44 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
+      }
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "right-align": {
@@ -32487,36 +33110,101 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "route-recognizer": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.2.10.tgz",
-      "integrity": "sha1-Aksig8LmjROnx/UXOlkkZF6JAt8="
+      "integrity": "sha1-Aksig8LmjROnx/UXOlkkZF6JAt8=",
+      "dev": true
     },
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -32526,14 +33214,51 @@
     },
     "source-map": {
       "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
       "requires": {
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        "source-map": "^0.5.6"
+      }
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
+      "dev": true
+    },
+    "sourcemap-validator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-1.1.0.tgz",
+      "integrity": "sha512-Hmdu39KL+EoAAZ69OTk7RXXJdPRRizJvOZOWhCW9jLGfEQflCNPTlSoCXFPdKWFwwf0uzLcGR/fc7EP/PT8vRQ==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.3.x",
+        "lodash.foreach": "~2.3.x",
+        "lodash.template": "~2.3.x",
+        "source-map": "~0.1.x"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.3.0.tgz",
+          "integrity": "sha1-G/XuY7RTn+LibQwemcJAuXpFeXI=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
       }
     },
     "spdx-correct": {
@@ -32542,7 +33267,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -32560,34 +33285,115 @@
     "sprintf-js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "string_decoder": {
       "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
       "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+        "buffer-shims": "~1.0.0"
       }
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "symlink-or-copy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz",
-      "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM="
+      "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM=",
+      "dev": true
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "tar": {
       "version": "2.2.1",
@@ -32595,9 +33401,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "text-table": {
@@ -32609,40 +33415,51 @@
     "textextensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.1.0.tgz",
-      "integrity": "sha1-G+DcKg3CRNRL6KCa9qha+5PE28M="
+      "integrity": "sha1-G+DcKg3CRNRL6KCa9qha+5PE28M=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+      "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.1"
       }
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
     },
     "tree-sync": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.2.2.tgz",
       "integrity": "sha1-LPdrhYn1n/7bWNtaOsfLAT0BWLc=",
+      "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "fs-tree-diff": "0.5.6",
-        "mkdirp": "0.5.1",
-        "quick-temp": "0.1.8",
-        "walk-sync": "0.2.7"
+        "debug": "^2.2.0",
+        "fs-tree-diff": "^0.5.6",
+        "mkdirp": "^0.5.1",
+        "quick-temp": "^0.1.5",
+        "walk-sync": "^0.2.7"
       },
       "dependencies": {
         "walk-sync": {
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
+          "dev": true,
           "requires": {
-            "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.5"
+            "ensure-posix-path": "^1.0.0",
+            "matcher-collection": "^1.0.0"
           }
         }
       }
@@ -32650,7 +33467,8 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "tweetnacl": {
       "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -32658,15 +33476,30 @@
       "dev": true,
       "optional": true
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
     "uglify-js": {
       "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
       "integrity": "sha1-1Uk0d4qNoUkD+imjJvskwKtRoaA=",
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-        "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -32679,19 +33512,28 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "dev": true,
       "requires": {
-        "sprintf-js": "1.1.1",
-        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "username-sync": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/username-sync/-/username-sync-1.0.1.tgz",
-      "integrity": "sha1-HN6H7vz5S4gimE2Ti6K3l0Jtrh8="
+      "integrity": "sha1-HN6H7vz5S4gimE2Ti6K3l0Jtrh8=",
+      "dev": true
     },
     "util-deprecate": {
       "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util-extend": {
       "version": "1.0.3",
@@ -32705,8 +33547,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "validate-npm-package-name": {
@@ -32722,9 +33564,19 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
       "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
+      "dev": true,
       "requires": {
-        "ensure-posix-path": "1.0.2",
-        "matcher-collection": "1.0.5"
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
       }
     },
     "window-size": {
@@ -32740,9 +33592,10 @@
       "optional": true
     },
     "workerpool": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.2.4.tgz",
-      "integrity": "sha512-gE7StiPAOM6318V3EzlR0sFgedAF11PjDZ1xt3SpbuF/vTTDFX2XEnkbFUNqhIHBEKzBDFLPgJSIXyJKP4wZBQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.1.tgz",
+      "integrity": "sha512-KdF/veTxbGCtJvQv/6ncHEvbFpUqGzkxDMeACnuQrErafJoigxjgv0x4IMq4/SmSPX+AoRf1OdtkjHsmAzhJPQ==",
+      "dev": true,
       "requires": {
         "object-assign": "4.1.1"
       }
@@ -32750,7 +33603,17 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "1.1.4",
@@ -32758,10 +33621,16 @@
       "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
+        "graceful-fs": "^4.1.2",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
       }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yargs": {
       "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
@@ -32769,10 +33638,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-        "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-        "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-mirage-nested",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",
@@ -18,6 +18,8 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "babel-eslint": "^8.2.1",
+    "ember-cli-eslint": "^4.2.1",
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.0.1",
     "ember-bootstrap": "0.11.3",
@@ -30,7 +32,6 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-jshint": "^1.0.0",
     "ember-cli-less": "1.5.3",
     "ember-cli-qunit": "^2.0.0",
     "ember-cli-release": "^0.2.9",
@@ -44,14 +45,14 @@
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-route-action-helper": "^2.0.0",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.1",
+    "ember-cli-mirage": "0.3.4"
   },
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-cli-mirage": "0.3.4"
+    "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import DS from 'ember-data';
 
 export default DS.RESTAdapter.extend({

--- a/tests/dummy/app/mirage-seed-data/debug-model/component.js
+++ b/tests/dummy/app/mirage-seed-data/debug-model/component.js
@@ -23,7 +23,7 @@ export default Component.extend({
   levelNew: computed('level', function () {
     return this.get('level') + 1;
   }),
-  flags: computed.readOnly('model.flags'),
+  flags: computed.readOnly('model.forGUI.flags'),
   error: null,
   childrenAssociations: computed('model.childrenAssociations', function () {
     let model = this.get('model');
@@ -41,10 +41,10 @@ export default Component.extend({
           })*/
           collapseName: relName,
           canAdd: (hasMany || !rel) &&
-            model.allowChangeNbAssociations &&
-            model.allowChangeNbAssociations.contains(relName),
-          canDelete: model.allowChangeNbAssociations &&
-            model.allowChangeNbAssociations.contains(relName)
+            model.forGUI.allowChangeNbAssociations &&
+            model.forGUI.allowChangeNbAssociations.contains(relName),
+          canDelete: model.forGUI.allowChangeNbAssociations &&
+            model.forGUI.allowChangeNbAssociations.contains(relName)
         };
       });
     } else {

--- a/tests/dummy/app/mirage-seed-data/route.js
+++ b/tests/dummy/app/mirage-seed-data/route.js
@@ -11,9 +11,7 @@ export default Ember.Route.extend({
     });
   },
   _writeSentence() {
-    let parent = server.schema.parents.all().models[0],
-      children = server.schema.children.all().models,
-      grandChildren = server.schema.grandChildren.all().models,
+    let children = server.schema.children.all().models,
       sent = ["let parent, children, grandChildren;"];
       sent.pushObject(["parent = server.create('parent');"]);
     sent.pushObject(`children = parent.hasMulti('children', ${children.length});`);

--- a/tests/dummy/mirage/models/bg-model.js
+++ b/tests/dummy/mirage/models/bg-model.js
@@ -1,0 +1,4 @@
+import { Model } from 'ember-cli-mirage';
+import EmberCliMirageNestedMixin from  'ember-cli-mirage-nested/mirage/bg-model-mixin';
+
+export default Model.extend(EmberCliMirageNestedMixin);

--- a/tests/dummy/mirage/models/child.js
+++ b/tests/dummy/mirage/models/child.js
@@ -1,7 +1,7 @@
-import Model from 'ember-cli-mirage-nested/mirage/bg-model';
+import BgModel from './bg-model';
 import { hasMany, belongsTo } from 'ember-cli-mirage';
 
-export default Model.extend({
+export default BgModel.extend({
   childrenAssociations: ['children'],
   allowChangeNbAssociations: ['children'],
   children: hasMany('grand-child', {inverse: 'parent'}),
@@ -10,11 +10,13 @@ export default Model.extend({
     this.update('title', 'The title attribute of this model is set on init in the "default" hook of the model.');
     this.hasMulti('children', 2);
   },
-  flags: [{
-    name: 'title',
-    options: [
-      'The title attribute of this model is set on init in the "default" hook of the model.',
-      'Also, this model has two children by default.'
-    ]
-  }],
+  forGUI: {
+    flags: [{
+      name: 'title',
+      options: [
+        'The title attribute of this model is set on init in the "default" hook of the model.',
+        'Also, this model has two children by default.'
+      ]
+    }],
+  }
 });

--- a/tests/dummy/mirage/models/grand-child.js
+++ b/tests/dummy/mirage/models/grand-child.js
@@ -1,6 +1,6 @@
-import Model from 'ember-cli-mirage-nested/mirage/bg-model';
+import BgModel from './bg-model';
 import { belongsTo } from 'ember-cli-mirage';
 
-export default Model.extend({
+export default BgModel.extend({
   parent: belongsTo('child')
 });

--- a/tests/dummy/mirage/models/parent.js
+++ b/tests/dummy/mirage/models/parent.js
@@ -1,8 +1,10 @@
-import Model from 'ember-cli-mirage-nested/mirage/bg-model';
+import BgModel from './bg-model';
 import { hasMany } from 'ember-cli-mirage';
 
-export default Model.extend({
+export default BgModel.extend({
   childrenAssociations: ['children'],
-  allowChangeNbAssociations: ['children'],
+  forGUI: {
+    allowChangeNbAssociations: ['children'],
+  },
   children: hasMany('child', {inverse: 'parent'})
 });


### PR DESCRIPTION
- [x] use javascript mixin instead of extending Mirage model in the addon (before this change, this was forcing consuming apps to use the ember-cli-mirage version set in the `dependencies` of this addon).

- [x] split the`GUI` part into a separate object `forGUI` in the Mirage models, for clarity.

- [x] add missing documentation in readme.

Next step will be to split this addon in two, **ember-cli-mirage-scenario-chaining** and **ember-cli-mirage-gui**. Also need to add Travis and tests to this repo.
